### PR TITLE
Exposes `hasFetchedObjects` from `FetchableRequest`

### DIFF
--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -26,6 +26,7 @@ public protocol FetchedResultsControllerProtocol: DoublyObservableObject {
 
     var definition: FetchDefinition<FetchedObject> { get }
 
+    /// Has performFetch() completed?
     var hasFetchedObjects: Bool { get }
     var sections: [Section] { get }
     var fetchedObjects: [FetchedObject] { get }

--- a/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
+++ b/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
@@ -17,6 +17,11 @@ public struct SectionedFetchableRequest<FetchedObject: FetchableObject>: Dynamic
         return SectionedFetchableResults(contents: _base.fetchController.sections)
     }
 
+    /// Has performFetch() completed?
+    public var hasFetchedObjects: Bool {
+        return _base.hasFetchedObjects
+    }
+
     public init(
         definition: FetchDefinition<FetchedObject>,
         sectionNameKeyPath: KeyPath<FetchedObject, String>,
@@ -56,6 +61,7 @@ public struct FetchableRequest<FetchedObject: FetchableObject>: DynamicProperty 
 
     private let animation: Animation?
 
+    /// Has performFetch() completed?
     public var hasFetchedObjects: Bool {
         return fetchController.hasFetchedObjects
     }

--- a/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
+++ b/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
@@ -56,7 +56,7 @@ public struct FetchableRequest<FetchedObject: FetchableObject>: DynamicProperty 
 
     private let animation: Animation?
 
-    internal var hasFetchedObjects: Bool {
+    public var hasFetchedObjects: Bool {
         return fetchController.hasFetchedObjects
     }
 


### PR DESCRIPTION
This accomodates allowing SwiftUI views to know when a fetch has completed.