### PR TITLE
Example and linter updates

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,52 @@
+--swiftversion 5.5
+
+--exclude Pods
+
+--rules anyObjectProtocol
+
+--rules braces
+
+--rules duplicateImports
+--rules elseOnSameLine
+
+--rules strongifiedSelf
+--rules andOperator
+
+--rules indent
+  --indent 4
+  --indentcase false
+  --indentstrings true
+  --ifdef outdent
+
+--rules leadingDelimiters
+--rules linebreakAtEndOfFile
+
+--rules redundantGet
+--rules redundantInit
+--rules redundantParens
+--rules redundantVoidReturnType
+--rules semicolons
+--rules spaceAroundBraces
+--rules spaceAroundBrackets
+--rules spaceAroundGenerics
+
+--rules spaceAroundOperators
+--rules spaceAroundParens
+--rules spaceInsideBraces
+--rules spaceInsideBrackets
+--rules spaceInsideComments
+--rules spaceInsideGenerics
+--rules spaceInsideParens
+--rules todos
+
+--rules trailingCommas
+--rules trailingSpace
+--rules typeSugar
+--rules void
+
+--rules wrapArguments
+  --wraparguments before-first
+  --wrapcollections before-first
+  --wrapparameters before-first
+
+--rules wrapMultilineStatementBraces

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,50 +9,64 @@ disabled_rules:
   - function_body_length
   - line_length
 opt_in_rules:
-  - sorted_first_last
+  - capture_variable
   - closure_spacing
   - closure_end_indentation
+  - collection_alignment
+  - comment_spacing
   - conditional_returns_on_newline
   - contains_over_first_not_nil
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_range_nil_comparison
+  - discarded_notification_center_observer
   - empty_count
+  - empty_collection_literal
+  - empty_string
+  - empty_xctest_method
   - explicit_init
   - fatal_error_message
   - first_where
+  - flatmap_over_map_reduce
+  - identical_operands
   - implicitly_unwrapped_optional
+  - joined_default_parameter
+  - last_where
+  - legacy_random
   - literal_expression_end_indentation
-  - multiline_arguments
-  - multiline_parameters
-  - number_separator
-  - overridden_super_call
-  - pattern_matching_keywords
-  - prohibited_super_call
-  - private_outlet
-  - redundant_nil_coalescing
-  - vertical_parameter_alignment_on_call
-  - untyped_error_in_catch
-  - empty_string
-  - empty_xctest_method
   - lower_acl_than_parent
   - modifier_order
-  - static_operator
-  - collection_alignment
-  - identical_operands
-  - toggle_bool
-  - legacy_random
-  - unused_import
-  - unused_declaration
-  - vertical_whitespace_between_cases
-  - redundant_objc_attribute
+  - multiline_arguments
+  - multiline_parameters
   - multiline_arguments_brackets
   - multiline_literal_brackets
   - multiline_parameters_brackets
   - nslocalizedstring_key
-  - last_where
+  - number_separator
+  - optional_enum_case_matching
+  - overridden_super_call
+  - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
+  - prohibited_super_call
+  - private_outlet
+  - private_subject
+  - private_unit_test
+  - reduce_into
+  - redundant_nil_coalescing
+  - redundant_objc_attribute
+  - sorted_first_last
+  - static_operator
+  - strong_iboutlet
+  - toggle_bool
+  - trailing_closure
+  - untyped_error_in_catch
+  - unused_import
+  - unused_declaration
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_between_cases
   - vertical_whitespace_opening_braces
   - vertical_whitespace_closing_braces
-  - strong_iboutlet
   - xct_specific_matcher
-  - trailing_closure
 excluded:
   - Pods
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Released on 2022-05-XX
 
 * Support array associations by an arbitrary reference instead of just by ID. This is specified via a new referenceAccessor parameter.
 * Updated example to use Codable model
+* Updated linting
 
 ## [4.0.2](https://github.com/square/FetchRequests/releases/tag/4.0.2)
 Released on 2021-12-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 Released on 2022-05-XX
 
 * Support array associations by an arbitrary reference instead of just by ID. This is specified via a new referenceAccessor parameter.
+* Updated example to use Codable model
 
 ## [4.0.2](https://github.com/square/FetchRequests/releases/tag/4.0.2)
 Released on 2021-12-14

--- a/Example/iOS-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/iOS-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "0959ba76a1d4a98fd11163aa83fd49c25b93bfae",
-          "version": "0.0.5"
-        }
+  "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "48254824bb4248676bf7ce56014ff57b142b77eb",
+        "version" : "1.0.2"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Example/iOS-Example/AppDelegate.swift
+++ b/Example/iOS-Example/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             rootViewController: ViewController()
         )
         window?.makeKeyAndVisible()
-        
+
         return true
     }
 }

--- a/Example/iOS-Example/Model+Persistence.swift
+++ b/Example/iOS-Example/Model+Persistence.swift
@@ -73,7 +73,7 @@ extension Model {
             return model
         }
         guard existing.updatedAt <= model.updatedAt,
-            existing.createdAt == model.createdAt
+              existing.createdAt == model.createdAt
         else {
             throw ModelError.invalidDate
         }

--- a/Example/iOS-Example/Model+Persistence.swift
+++ b/Example/iOS-Example/Model+Persistence.swift
@@ -12,8 +12,10 @@ import FetchRequests
 
 enum ModelError: Error {
     case invalidDate
-    case cannotInflate
 }
+
+private let encoder = JSONEncoder()
+private let decoder = JSONDecoder()
 
 // MARK: - Event Notifications
 
@@ -45,24 +47,22 @@ extension Model {
         return UserDefaults.standard.dictionary(forKey: key) ?? [:]
     }
 
-    fileprivate class func updateStorage(_ block: (inout [String: Any]) -> Void) {
+    fileprivate class func updateStorage(_ block: (inout [String: Any]) throws -> Void) rethrows {
         assert(Thread.isMainThread)
 
         let defaults = UserDefaults.standard
         let key = NSStringFromClass(self)
 
         var storage = defaults.dictionary(forKey: key) ?? [:]
-        block(&storage)
+        try block(&storage)
         defaults.set(storage, forKey: key)
     }
 
     private class func validateCanUpdate(_ originalModel: Model) throws -> Model {
-        var data = originalModel.data.dictionary ?? [:]
-        data["updatedAt"] = Date().timeIntervalSince1970
+        var data = originalModel.data
+        data.updatedAt = Date()
 
-        guard let json = JSON(data), let model = self.init(data: json) else {
-            throw ModelError.cannotInflate
-        }
+        let model = Model(data: data)
 
         guard model.createdAt != .distantPast else {
             throw ModelError.invalidDate
@@ -73,8 +73,8 @@ extension Model {
             return model
         }
         guard existing.updatedAt <= model.updatedAt,
-            existing.createdAt == model.createdAt else
-        {
+            existing.createdAt == model.createdAt
+        else {
             throw ModelError.invalidDate
         }
 
@@ -85,8 +85,9 @@ extension Model {
     class func save(_ originalModel: Model) throws {
         let model = try validateCanUpdate(originalModel)
 
-        updateStorage {
-            $0[model.id] = model.data.object
+        try updateStorage {
+            let data = try encoder.encode(model.data)
+            $0[model.id] = data
         }
 
         NotificationCenter.default.post(
@@ -124,17 +125,21 @@ extension Model {
 
 extension NSObjectProtocol where Self: Model {
     static func fetchAll() -> [Self] {
-        return storage.values.lazy.compactMap {
-            Self.RawData($0)
-        }.compactMap {
+        return storage.values.lazy.compactMap { value in
+            value as? Data
+        }.compactMap { data in
+            try? decoder.decode(Model.RawData.self, from: data)
+        }.map {
             Self(data: $0)
         }
     }
 
     static func fetch(byID id: Model.ID) -> Self? {
-        return storage[id].flatMap {
-            Self.RawData($0)
-        }.flatMap {
+        return storage[id].flatMap { value in
+            value as? Data
+        }.flatMap { data in
+            try? decoder.decode(Model.RawData.self, from: data)
+        }.map {
             Self(data: $0)
         }
     }

--- a/Example/iOS-Example/ViewController.swift
+++ b/Example/iOS-Example/ViewController.swift
@@ -130,7 +130,7 @@ private extension ViewController {
     }
 }
 
-// MARK: - CWFetchedResultsControllerDelegate
+// MARK: - FetchedResultsControllerDelegate
 
 extension ViewController: FetchedResultsControllerDelegate {
     func controllerWillChangeContent(_ controller: FetchedResultsController<Model>) {

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -638,7 +638,6 @@ public extension FetchRequestAssociation {
         )
     }
 
-
     /// Array association by optional entity IDs whose creation event can also be observed
     convenience init<
         AssociatedEntity: FetchableObject,

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -137,7 +137,7 @@ public extension FetchRequestAssociation {
         RawAssociatedEntity,
         AssociatedEntityID: Equatable,
         Token: ObservableToken
-    > (
+    >(
         keyPath: KeyPath<FetchedObject, AssociatedEntityID>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
@@ -200,7 +200,7 @@ public extension FetchRequestAssociation {
         RawAssociatedEntity,
         AssociatedEntityID: Equatable,
         Token: ObservableToken
-    > (
+    >(
         keyPath: KeyPath<FetchedObject, AssociatedEntityID?>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
@@ -262,7 +262,7 @@ public extension FetchRequestAssociation {
         AssociatedEntity: FetchableObject,
         AssociatedEntityID: Equatable,
         Token: ObservableToken
-    > (
+    >(
         keyPath: KeyPath<FetchedObject, AssociatedEntityID>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
@@ -313,7 +313,7 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         Token: ObservableToken
-    > (
+    >(
         for associatedType: AssociatedEntity.Type,
         keyPath: KeyPath<FetchedObject, AssociatedEntity.ID>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
@@ -401,7 +401,7 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         Token: ObservableToken
-    > (
+    >(
         for associatedType: AssociatedEntity.Type,
         keyPath: KeyPath<FetchedObject, AssociatedEntity.ID?>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
@@ -497,7 +497,7 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         Token: ObservableToken
-    > (
+    >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [AssociatedEntity.ID]>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
@@ -519,7 +519,7 @@ public extension FetchRequestAssociation {
         AssociatedEntity: FetchableObject,
         Reference: Hashable,
         Token: ObservableToken
-    > (
+    >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [Reference]>,
         request: @escaping AssocationRequestByID<Reference, AssociatedEntity>,
@@ -621,7 +621,7 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         Token: ObservableToken
-    > (
+    >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [AssociatedEntity.ID]?>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
@@ -643,7 +643,7 @@ public extension FetchRequestAssociation {
         AssociatedEntity: FetchableObject,
         Reference: Hashable,
         Token: ObservableToken
-    > (
+    >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [Reference]?>,
         request: @escaping AssocationRequestByID<Reference, AssociatedEntity>,
@@ -657,8 +657,8 @@ public extension FetchRequestAssociation {
             let mapping: [FetchedObject.ID: [Reference]] = objects.reduce(into: [:]) { memo, object in
                 let objectID = object.id
                 guard let associatedIDs: [Reference] = object[keyPath: keyPath],
-                    !associatedIDs.isEmpty else
-                {
+                      !associatedIDs.isEmpty
+                else {
                     return
                 }
                 for associatedID in associatedIDs {
@@ -749,7 +749,7 @@ public extension FetchRequestAssociation {
     convenience init<
         EntityID: FetchableEntityID,
         Token: ObservableToken
-    > (
+    >(
         keyPath: KeyPath<FetchedObject, EntityID>,
         creationTokenGenerator: @escaping TokenGenerator<EntityID, Token>,
         preferExistingValueOnCreate: Bool
@@ -821,7 +821,7 @@ public extension FetchRequestAssociation {
     convenience init<
         EntityID: FetchableEntityID,
         Token: ObservableToken
-    > (
+    >(
         keyPath: KeyPath<FetchedObject, EntityID?>,
         creationTokenGenerator: @escaping TokenGenerator<EntityID, Token>,
         preferExistingValueOnCreate: Bool

--- a/FetchRequests/Sources/BoxedJSON.swift
+++ b/FetchRequests/Sources/BoxedJSON.swift
@@ -76,15 +76,15 @@ extension JSON: _ObjectiveCBridgeable {
     }
 
     public static func _forceBridgeFromObjectiveC(
-      _ source: BoxedJSON,
-      result: inout JSON?
+        _ source: BoxedJSON,
+        result: inout JSON?
     ) {
         result = source.json
     }
 
     public static func _conditionallyBridgeFromObjectiveC(
-      _ source: BoxedJSON,
-      result: inout JSON?
+        _ source: BoxedJSON,
+        result: inout JSON?
     ) -> Bool {
         result = source.json
         return true
@@ -93,8 +93,8 @@ extension JSON: _ObjectiveCBridgeable {
     public static func _unconditionallyBridgeFromObjectiveC(
         _ source: BoxedJSON?
     ) -> JSON {
-      var result: JSON?
-      _forceBridgeFromObjectiveC(source!, result: &result)
-      return result!
+        var result: JSON?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
     }
 }

--- a/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
@@ -74,7 +74,8 @@ public struct CollapsibleResultsSection<FetchedObject: FetchableObject>: Equatab
         }
 
         if let numberOfItemsToDisplayWhenExceedingMax = config.numberOfItemsToDisplayWhenExceedingMax,
-            section.numberOfObjects > config.maxNumberOfItemsToDisplay {
+           section.numberOfObjects > config.maxNumberOfItemsToDisplay
+        {
             let collapsedObjects = section.objects.prefix(numberOfItemsToDisplayWhenExceedingMax)
             displayableObjects = Array(collapsedObjects)
         } else if section.numberOfObjects > config.maxNumberOfItemsToDisplay {
@@ -280,8 +281,8 @@ extension CollapsibleSectionsFetchedResultsController: FetchedResultsControllerD
         }
         for sectionName in sectionsToNotify {
             guard let section = previousSectionsDuringContentChange.first(where: { $0.name == sectionName }),
-                let index = previousSectionsDuringContentChange.firstIndex(of: section) else
-            {
+                  let index = previousSectionsDuringContentChange.firstIndex(of: section)
+            else {
                 continue
             }
 
@@ -330,7 +331,7 @@ extension CollapsibleSectionsFetchedResultsController: FetchedResultsControllerD
             let fromSection = sections[fromIndexPath.section]
             let toSection = sections[toIndexPath.section]
 
-            if fromSection.isCollapsed && toSection.isCollapsed {
+            if fromSection.isCollapsed, toSection.isCollapsed {
                 collapsedSectionsModifiedDuringContentChange.insert(fromSection.name)
                 collapsedSectionsModifiedDuringContentChange.insert(toSection.name)
             } else if fromSection.isCollapsed {

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -181,13 +181,13 @@ public class FetchedResultsController<FetchedObject: FetchableObject>: NSObject,
     private var associatedValues: [AssociatedValueKey<FetchedObject>: AssociatedValueReference] = [:]
 
     private let memoryPressureToken: FetchRequestObservableToken<Notification>? = {
-        #if canImport(UIKit) && !os(watchOS)
+#if canImport(UIKit) && !os(watchOS)
         return FetchRequestObservableToken(
             token: ObservableNotificationCenterToken(name: UIApplication.didReceiveMemoryWarningNotification)
         )
-        #else
+#else
         return nil
-        #endif
+#endif
     }()
 
     // swiftlint:disable:next weak_delegate
@@ -228,7 +228,7 @@ public class FetchedResultsController<FetchedObject: FetchableObject>: NSObject,
 
     private lazy var context: Context<FetchedObject> = {
         return Context { [weak self] keyPath, objectID in
-            guard let `self` = self else {
+            guard let self = self else {
                 throw FetchedResultsError.objectNotFound
             }
 
@@ -380,7 +380,7 @@ private extension FetchedResultsController {
             let smallIndex = max(0, index - difference)
             let largeIndex = min(fetchedObjects.endIndex - 1, index + difference)
 
-            objects = Array(fetchedObjects[smallIndex...largeIndex])
+            objects = Array(fetchedObjects[smallIndex ... largeIndex])
         }
         let fetchableObjects = objects.filter {
             let objectID = $0.id
@@ -838,11 +838,11 @@ private extension FetchedResultsController {
 
     func insert(_ object: FetchedObject, atIndex index: Int, emitChanges: Bool = true) {
         assert(fetchedObjectIDs.contains(object.id))
-        
+
         let sectionName = object.sectionName(forKeyPath: sectionNameKeyPath)
         let sectionIndex = idealSectionIndex(forSectionName: sectionName)
 
-        let sectionPrefix = sections[0..<sectionIndex].reduce(0) { $0 + $1.numberOfObjects }
+        let sectionPrefix = sections[0 ..< sectionIndex].reduce(0) { $0 + $1.numberOfObjects }
         let sectionObjectIndex = index - sectionPrefix
 
         if sections.endIndex <= sectionIndex || sections[sectionIndex].name != sectionName {
@@ -878,7 +878,7 @@ private extension FetchedResultsController {
         }
 
         let handleChange: (FetchedObject) -> Void = { [weak self] object in
-            guard let `self` = self else {
+            guard let self = self else {
                 return
             }
             do {
@@ -909,7 +909,7 @@ private extension FetchedResultsController {
         observations += [dataObserver, isDeletedObserver]
 
         let handleSort: (FetchedObject, Bool, Any?, Any?) -> Void = { [weak self] object, isSection, old, new in
-            guard let `self` = self else {
+            guard let self = self else {
                 return
             }
             if let old = old as? NSObject, let new = new as? NSObject {
@@ -966,7 +966,7 @@ private extension FetchedResultsController {
     func startObservingNotificationsIfNeeded() {
         assert(Thread.isMainThread)
 
-        memoryPressureToken?.observeIfNeeded { [ weak self] notification in
+        memoryPressureToken?.observeIfNeeded { [weak self] notification in
             self?.removeAllAssociatedValues()
         }
         definition.objectCreationToken.observeIfNeeded { [weak self] data in

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -113,7 +113,7 @@ public extension FetchedResultsControllerProtocol {
             return nil
         }
 
-        let sectionPrefix = sections[0..<indexPath.section].reduce(0) { $0 + $1.numberOfObjects }
+        let sectionPrefix = sections[0 ..< indexPath.section].reduce(0) { $0 + $1.numberOfObjects }
 
         return sectionPrefix + indexPath.item
     }
@@ -147,7 +147,7 @@ public extension FetchedResultsControllerProtocol {
 
 public extension FetchedResultsControllerProtocol {
     func getIndexPath(before indexPath: IndexPath) -> IndexPath? {
-        guard 0..<sections.count ~= indexPath.section else {
+        guard 0 ..< sections.count ~= indexPath.section else {
             return nil
         }
 
@@ -168,7 +168,7 @@ public extension FetchedResultsControllerProtocol {
     }
 
     func getIndexPath(after indexPath: IndexPath) -> IndexPath? {
-        guard 0..<sections.count ~= indexPath.section else {
+        guard 0 ..< sections.count ~= indexPath.section else {
             return nil
         }
 

--- a/FetchRequests/Sources/Logging.swift
+++ b/FetchRequests/Sources/Logging.swift
@@ -32,32 +32,32 @@ func CWLogError(_ message: @autoclosure () -> String, level: DDLogLevel = dynami
 }
 #else
 func CWLogDebug(_ message: @autoclosure () -> String) {
-    #if DEBUG
+#if DEBUG
     NSLog(message())
-    #endif
+#endif
 }
 
 func CWLogInfo(_ message: @autoclosure () -> String) {
-    #if DEBUG
+#if DEBUG
     NSLog(message())
-    #endif
+#endif
 }
 
 func CWLogWarning(_ message: @autoclosure () -> String) {
-    #if DEBUG
+#if DEBUG
     NSLog(message())
-    #endif
+#endif
 }
 
 func CWLogVerbose(_ message: @autoclosure () -> String) {
-    #if DEBUG
+#if DEBUG
     NSLog(message())
-    #endif
+#endif
 }
 
 func CWLogError(_ message: @autoclosure () -> String) {
-    #if DEBUG
+#if DEBUG
     NSLog(message())
-    #endif
+#endif
 }
 #endif

--- a/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
+++ b/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
@@ -79,7 +79,7 @@ public class PausablePaginatingFetchedResultsController<
     FetchedObject: FetchableObject
 >: PausableFetchedResultsController<FetchedObject> {
     private unowned let paginatingDefinition: PaginatingFetchDefinition<FetchedObject>
-    
+
     public init(
         definition: PaginatingFetchDefinition<FetchedObject>,
         sortDescriptors: [NSSortDescriptor] = [],
@@ -87,7 +87,7 @@ public class PausablePaginatingFetchedResultsController<
         debounceInsertsAndReloads: Bool = true
     ) {
         paginatingDefinition = definition
-        
+
         super.init(
             definition: definition,
             sortDescriptors: sortDescriptors,
@@ -95,7 +95,7 @@ public class PausablePaginatingFetchedResultsController<
             debounceInsertsAndReloads: debounceInsertsAndReloads
         )
     }
-    
+
     public func performPagination() {
         performPagination(with: paginatingDefinition.paginationRequest)
     }

--- a/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
+++ b/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
@@ -147,28 +147,28 @@ public struct SectionedFetchableResults<FetchedObject: FetchableObject> {
 
 extension FetchableResults: RandomAccessCollection {
     public var startIndex: Int {
-      return contents.startIndex
+        return contents.startIndex
     }
 
     public var endIndex: Int {
-      return contents.endIndex
+        return contents.endIndex
     }
 
-    public subscript (position: Int) -> FetchedObject {
+    public subscript(position: Int) -> FetchedObject {
         return contents[position]
     }
 }
 
 extension SectionedFetchableResults: RandomAccessCollection {
     public var startIndex: Int {
-      return contents.startIndex
+        return contents.startIndex
     }
 
     public var endIndex: Int {
-      return contents.endIndex
+        return contents.endIndex
     }
 
-    public subscript (position: Int) -> FetchedResultsSection<FetchedObject> {
+    public subscript(position: Int) -> FetchedResultsSection<FetchedObject> {
         return contents[position]
     }
 }

--- a/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
@@ -32,7 +32,7 @@ class CollapsibleSectionsFetchedResultsControllerTestCase: XCTestCase {
         let request: FetchDefinition<TestObject>.Request = { [unowned self] completion in
             self.fetchCompletion = completion
         }
-        
+
         let desiredAssociations = TestObject.fetchRequestAssociations(
             matching: associations
         ) { [unowned self] associationRequest in
@@ -708,7 +708,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    #if canImport(UIKit) && !os(watchOS)
+#if canImport(UIKit) && !os(watchOS)
     func testAssociatedValuesAreDumpedOnMemoryPressure() {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
@@ -744,7 +744,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         associationRequest.parentsCompletion([:])
     }
-    #endif
+#endif
 
     func testAssociatedObjectsInvalidatedFromKVO() {
         controller = FetchController(

--- a/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
@@ -390,7 +390,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    #if canImport(UIKit) && !os(watchOS)
+#if canImport(UIKit) && !os(watchOS)
     func testAssociatedValuesAreDumpedOnMemoryPressure() {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
@@ -426,7 +426,7 @@ extension FetchedResultsControllerTestCase {
 
         associationRequest.parentsCompletion([:])
     }
-    #endif
+#endif
 
     func testAssociatedObjectsInvalidatedFromKVO() {
         controller = FetchedResultsController(
@@ -855,7 +855,7 @@ extension FetchedResultsControllerTestCase {
         }
 
         try! performFetch(objects)
-        
+
         // Fault on A
 
         let faultedAssociatedObject = getObjectAtIndex(0, withObjectID: "a").tagObjectArray()

--- a/FetchRequests/Tests/Models/FetchRequestAssociationTestCase.swift
+++ b/FetchRequests/Tests/Models/FetchRequestAssociationTestCase.swift
@@ -72,7 +72,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? Int), 2)
+            XCTAssertEqual(newValue as? Int, 2)
             calledKVO = true
         }
 
@@ -114,7 +114,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? String), "2")
+            XCTAssertEqual(newValue as? String, "2")
             calledKVO = true
         }
 
@@ -181,7 +181,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? Int), 2)
+            XCTAssertEqual(newValue as? Int, 2)
             calledKVO = true
         }
 
@@ -244,7 +244,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? String), "2")
+            XCTAssertEqual(newValue as? String, "2")
             calledKVO = true
         }
 
@@ -312,7 +312,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? String), "2")
+            XCTAssertEqual(newValue as? String, "2")
             calledKVO = true
         }
 
@@ -376,7 +376,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? String), "2")
+            XCTAssertEqual(newValue as? String, "2")
             calledKVO = true
         }
 
@@ -448,7 +448,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? [String]), ["2"])
+            XCTAssertEqual(newValue as? [String], ["2"])
             calledKVO = true
         }
 
@@ -516,7 +516,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? [String]), ["2"])
+            XCTAssertEqual(newValue as? [String], ["2"])
             calledKVO = true
         }
 
@@ -579,7 +579,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? TestFetchableEntityID), TestFetchableEntityID(id: "2"))
+            XCTAssertEqual(newValue as? TestFetchableEntityID, TestFetchableEntityID(id: "2"))
             calledKVO = true
         }
 
@@ -638,7 +638,7 @@ extension FetchRequestAssociationTestCase {
 
         var calledKVO = false
         let observer = association.observeKeyPath(object) { object, oldValue, newValue in
-            XCTAssertEqual((newValue as? TestFetchableEntityID), TestFetchableEntityID(id: "2"))
+            XCTAssertEqual(newValue as? TestFetchableEntityID, TestFetchableEntityID(id: "2"))
             calledKVO = true
         }
 

--- a/FetchRequests/Tests/TestObject+FetchableObject.swift
+++ b/FetchRequests/Tests/TestObject+FetchableObject.swift
@@ -9,7 +9,7 @@
 import Foundation
 import FetchRequests
 
-// MARK: - CWFetchableObjectProtocol
+// MARK: - FetchableObjectProtocol
 
 extension TestObject: FetchableObjectProtocol {
     func observeDataChanges(_ handler: @escaping () -> Void) -> InvalidatableToken {
@@ -39,10 +39,10 @@ extension TestObject: FetchableObjectProtocol {
 
 extension TestObject {
     static func objectWasCreated() -> Notification.Name {
-        return Notification.Name("CWTestObject.objectWasCreated")
+        return Notification.Name("TestObject.objectWasCreated")
     }
 
     static func dataWasCleared() -> Notification.Name {
-        return Notification.Name("CWTestObject.dataWasCleared")
+        return Notification.Name("TestObject.dataWasCleared")
     }
 }

--- a/FetchRequests/Tests/TestObject.swift
+++ b/FetchRequests/Tests/TestObject.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@testable import FetchRequests
+import FetchRequests
 
 final class TestObject: NSObject {
     typealias RawData = JSON
@@ -39,6 +39,8 @@ final class TestObject: NSObject {
 
         return hasher.finalize()
     }
+
+    // MARK: - Initialization & Integration
 
     required init?(data: RawData) {
         guard let id = TestObject.entityID(from: data) else {


### PR DESCRIPTION
This updates the example project to use a Codable object, since that is going to be far more useful for someone new.
Further, I synchronized the linter rules with our internal configuration and ran `swiftformat`.

Note: I have not made `swiftformat` auto-run anywhere at the moment.