### PR TITLE
Avoid no-op eventing

### DIFF
--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -607,7 +607,7 @@ private extension FetchedResultsController {
             return !fetchedObjectIDs.contains(object.id)
         }.sorted(by: sortDescriptors)
 
-        guard !objects.isEmpty else {
+        guard !sortedObjects.isEmpty else {
             return
         }
 


### PR DESCRIPTION
### What

Avoid a no-op triggering willChange and didChange events

### How

Evaluate the objects that would _actually_ be inserted, instead of the unfiltered list.