### PR TITLE
Generic Protocols

### DIFF
--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -488,7 +488,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 471C508022C6D0DC007F73E9 /* Build configuration list for PBXNativeTarget "FetchRequests-iOS" */;
 			buildPhases = (
-				4736ABDC22CC3A1500253EB6 /* SwiftLint */,
 				471C506722C6D0DB007F73E9 /* Headers */,
 				471C506822C6D0DB007F73E9 /* Sources */,
 				471C506922C6D0DB007F73E9 /* Frameworks */,
@@ -746,27 +745,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		4736ABDC22CC3A1500253EB6 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "PATH=$PATH:/usr/local/bin:/opt/homebrew/bin:/opt/brew/bin\n\nif which swiftlint >/dev/null; then\n    swiftlint --strict\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		471C506822C6D0DB007F73E9 /* Sources */ = {

--- a/FetchRequests.xcodeproj/project.pbxproj
+++ b/FetchRequests.xcodeproj/project.pbxproj
@@ -648,7 +648,7 @@
 			attributes = {
 				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1400;
 				ORGANIZATIONNAME = "Speramus Inc.";
 				TargetAttributes = {
 					471C506B22C6D0DB007F73E9 = {
@@ -1268,6 +1268,7 @@
 		47A6ED4422CA90A20034A854 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1282,6 +1283,7 @@
 		47A6ED4522CA90A20034A854 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1297,6 +1299,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				INFOPLIST_FILE = FetchRequests/TestsInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1313,6 +1316,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEAD_CODE_STRIPPING = YES;
 				INFOPLIST_FILE = FetchRequests/TestsInfo.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-iOS.xcscheme
+++ b/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-macOS.xcscheme
+++ b/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-tvOS.xcscheme
+++ b/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-watchOS.xcscheme
+++ b/FetchRequests.xcodeproj/xcshareddata/xcschemes/FetchRequests-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -748,12 +748,12 @@ public extension FetchRequestAssociation {
     /// Association by non-optional entity ID whose creation event can also be observed
     convenience init<
         EntityID: FetchableEntityID,
-        Token: ObservableToken
+        Token: ObservableToken<EntityID.FetchableEntity.RawData>
     >(
         keyPath: KeyPath<FetchedObject, EntityID>,
         creationTokenGenerator: @escaping TokenGenerator<EntityID, Token>,
         preferExistingValueOnCreate: Bool
-    ) where Token.Parameter == EntityID.FetchableEntity.RawData {
+    ) {
         typealias AssociatedType = EntityID.FetchableEntity
 
         var valuesSet: Set<EntityID> = []
@@ -820,12 +820,12 @@ public extension FetchRequestAssociation {
     /// Association by optional entity ID whose creation event can also be observed
     convenience init<
         EntityID: FetchableEntityID,
-        Token: ObservableToken
+        Token: ObservableToken<EntityID.FetchableEntity.RawData>
     >(
         keyPath: KeyPath<FetchedObject, EntityID?>,
         creationTokenGenerator: @escaping TokenGenerator<EntityID, Token>,
         preferExistingValueOnCreate: Bool
-    ) where Token.Parameter == EntityID.FetchableEntity.RawData {
+    ) {
         typealias AssociatedType = EntityID.FetchableEntity
 
         var valuesSet: Set<EntityID> = []

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -905,8 +905,8 @@ private extension Sequence {
     }
 }
 
-private extension Sequence where Iterator.Element: FetchableObjectProtocol {
-    func createLookupTable() -> [Iterator.Element.ID: Iterator.Element] {
+private extension Sequence where Element: FetchableObjectProtocol {
+    func createLookupTable() -> [Element.ID: Element] {
         return self.associated(by: \.id)
     }
 }

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -136,13 +136,13 @@ public extension FetchRequestAssociation {
         AssociatedEntity: FetchableObject,
         RawAssociatedEntity,
         AssociatedEntityID: Equatable,
-        Token: ObservableToken
+        Token: ObservableToken<RawAssociatedEntity>
     >(
         keyPath: KeyPath<FetchedObject, AssociatedEntityID>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         creationObserved: @escaping CreationObserved<AssociatedEntity, RawAssociatedEntity>
-    ) where Token.Parameter == RawAssociatedEntity {
+    ) {
         let creationTokenGenerator: TokenGenerator<FetchedObject, FetchRequestObservableToken<Any>> = { parentObject in
             let token = creationTokenGenerator(parentObject)
             return token.map { FetchRequestObservableToken(typeErasedToken: $0) }
@@ -199,13 +199,13 @@ public extension FetchRequestAssociation {
         AssociatedEntity: FetchableObject,
         RawAssociatedEntity,
         AssociatedEntityID: Equatable,
-        Token: ObservableToken
+        Token: ObservableToken<RawAssociatedEntity>
     >(
         keyPath: KeyPath<FetchedObject, AssociatedEntityID?>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         creationObserved: @escaping CreationObserved<AssociatedEntity, RawAssociatedEntity>
-    ) where Token.Parameter == RawAssociatedEntity {
+    ) {
         let creationTokenGenerator: TokenGenerator<FetchedObject, FetchRequestObservableToken<Any>> = { parentObject in
             let token = creationTokenGenerator(parentObject)
             return token.map { FetchRequestObservableToken(typeErasedToken: $0) }
@@ -261,13 +261,13 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         AssociatedEntityID: Equatable,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity>
     >(
         keyPath: KeyPath<FetchedObject, AssociatedEntityID>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         preferExistingValueOnCreate: Bool
-    ) where Token.Parameter == AssociatedEntity {
+    ) {
         self.init(
             keyPath: keyPath,
             request: request,
@@ -285,13 +285,13 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         AssociatedEntityID: Equatable,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity>
     >(
         keyPath: KeyPath<FetchedObject, AssociatedEntityID?>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         preferExistingValueOnCreate: Bool
-    ) where Token.Parameter == AssociatedEntity {
+    ) {
         self.init(
             keyPath: keyPath,
             request: request,
@@ -312,14 +312,14 @@ public extension FetchRequestAssociation {
     /// Association by non-optional entity ID whose creation event can also be observed
     convenience init<
         AssociatedEntity: FetchableObject,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: AssociatedEntity.Type,
         keyPath: KeyPath<FetchedObject, AssociatedEntity.ID>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<AssociatedEntity.ID, Token>,
         preferExistingValueOnCreate: Bool
-    ) where Token.Parameter == AssociatedEntity.RawData {
+    ) {
         let rawRequest: AssocationRequestByParent<Any> = { objects, completion in
             var valuesSet: Set<AssociatedEntity.ID> = []
             var valuesOrdered: [AssociatedEntity.ID] = []
@@ -400,14 +400,14 @@ public extension FetchRequestAssociation {
     /// Association by optional entity ID whose creation event can also be observed
     convenience init<
         AssociatedEntity: FetchableObject,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: AssociatedEntity.Type,
         keyPath: KeyPath<FetchedObject, AssociatedEntity.ID?>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<AssociatedEntity.ID, Token>,
         preferExistingValueOnCreate: Bool
-    ) where Token.Parameter == AssociatedEntity.RawData {
+    ) {
         let rawRequest: AssocationRequestByParent<Any> = { objects, completion in
             var valuesSet: Set<AssociatedEntity.ID> = []
             var valuesOrdered: [AssociatedEntity.ID] = []
@@ -496,14 +496,14 @@ public extension FetchRequestAssociation {
     /// Array association by non-optional entity IDs whose creation event can also be observed
     convenience init<
         AssociatedEntity: FetchableObject,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [AssociatedEntity.ID]>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<[AssociatedEntity.ID], Token>,
         creationObserved: @escaping CreationObserved<[AssociatedEntity], AssociatedEntity.RawData>
-    ) where Token.Parameter == AssociatedEntity.RawData {
+    ) {
         self.init(
             for: associatedType,
             keyPath: keyPath,
@@ -518,7 +518,7 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         Reference: Hashable,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [Reference]>,
@@ -526,7 +526,7 @@ public extension FetchRequestAssociation {
         referenceAccessor: @escaping (AssociatedEntity) -> Reference,
         creationTokenGenerator: @escaping TokenGenerator<[Reference], Token>,
         creationObserved: @escaping CreationObserved<[AssociatedEntity], AssociatedEntity.RawData>
-    ) where Token.Parameter == AssociatedEntity.RawData {
+    ) {
         let rawRequest: AssocationRequestByParent<Any> = { objects, completion in
             var valuesSet: Set<Reference> = []
             var valuesOrdered: [Reference] = []
@@ -620,14 +620,14 @@ public extension FetchRequestAssociation {
     /// Array association by optional entity IDs whose creation event can also be observed
     convenience init<
         AssociatedEntity: FetchableObject,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [AssociatedEntity.ID]?>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<[AssociatedEntity.ID], Token>,
         creationObserved: @escaping CreationObserved<[AssociatedEntity], AssociatedEntity.RawData>
-    ) where Token.Parameter == AssociatedEntity.RawData {
+    ) {
         self.init(
             for: associatedType,
             keyPath: keyPath,
@@ -642,7 +642,7 @@ public extension FetchRequestAssociation {
     convenience init<
         AssociatedEntity: FetchableObject,
         Reference: Hashable,
-        Token: ObservableToken
+        Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
         keyPath: KeyPath<FetchedObject, [Reference]?>,
@@ -650,7 +650,7 @@ public extension FetchRequestAssociation {
         referenceAccessor: @escaping (AssociatedEntity) -> Reference,
         creationTokenGenerator: @escaping TokenGenerator<[Reference], Token>,
         creationObserved: @escaping CreationObserved<[AssociatedEntity], AssociatedEntity.RawData>
-    ) where Token.Parameter == AssociatedEntity.RawData {
+    ) {
         let rawRequest: AssocationRequestByParent<Any> = { objects, completion in
             var valuesSet: Set<Reference> = []
             var valuesOrdered: [Reference] = []

--- a/FetchRequests/Sources/Associations/FetchableEntityID.swift
+++ b/FetchRequests/Sources/Associations/FetchableEntityID.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol FetchableEntityID: Hashable {
+public protocol FetchableEntityID<FetchableEntity>: Hashable {
     associatedtype FetchableEntity: FetchableObject
 
     init?(from entity: FetchableEntity)

--- a/FetchRequests/Sources/Associations/ObservableToken.swift
+++ b/FetchRequests/Sources/Associations/ObservableToken.swift
@@ -21,7 +21,7 @@ public protocol InvalidatableToken: AnyObject {
     func invalidate()
 }
 
-public protocol ObservableToken: InvalidatableToken {
+public protocol ObservableToken<Parameter>: InvalidatableToken {
     associatedtype Parameter
 
     func observe(handler: @escaping (Parameter) -> Void)

--- a/FetchRequests/Sources/Associations/ObservableToken.swift
+++ b/FetchRequests/Sources/Associations/ObservableToken.swift
@@ -136,7 +136,7 @@ internal class FetchRequestObservableToken<Parameter>: ObservableToken {
         _invalidate = invalidate
     }
 
-    init<Token: ObservableToken>(token: Token) where Token.Parameter == Parameter {
+    init(token: some ObservableToken<Parameter>) {
         _observe = { token.observe(handler: $0) }
         _invalidate = { token.invalidate() }
     }

--- a/FetchRequests/Sources/CollectionType+SortDescriptors.swift
+++ b/FetchRequests/Sources/CollectionType+SortDescriptors.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public extension Sequence where Iterator.Element: NSSortDescriptor {
+public extension Sequence where Element: NSSortDescriptor {
     var comparator: Comparator {
         return { lhs, rhs in
             for sort in self {
@@ -22,8 +22,8 @@ public extension Sequence where Iterator.Element: NSSortDescriptor {
     }
 }
 
-public extension Sequence where Iterator.Element: NSObject {
-    func sorted(by descriptors: [NSSortDescriptor]) -> [Iterator.Element] {
+public extension Sequence where Element: NSObject {
+    func sorted(by descriptors: [NSSortDescriptor]) -> [Element] {
         guard !descriptors.isEmpty else {
             return Array(self)
         }
@@ -31,7 +31,7 @@ public extension Sequence where Iterator.Element: NSObject {
         return sorted(by: descriptors.comparator)
     }
 
-    private func sorted(by comparator: Comparator) -> [Iterator.Element] {
+    private func sorted(by comparator: Comparator) -> [Element] {
         return sorted { comparator($0, $1) == .orderedAscending }
     }
 }

--- a/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
@@ -18,7 +18,7 @@ public struct SectionCollapseConfig: Equatable {
     }
 }
 
-public protocol CollapsibleSectionsFetchedResultsControllerDelegate: AnyObject {
+public protocol CollapsibleSectionsFetchedResultsControllerDelegate<FetchedObject>: AnyObject {
     associatedtype FetchedObject: FetchableObject
 
     func controllerWillChangeContent(_ controller: CollapsibleSectionsFetchedResultsController<FetchedObject>)

--- a/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
@@ -159,7 +159,11 @@ public class CollapsibleSectionsFetchedResultsController<FetchedObject: Fetchabl
         fetchController.setDelegate(self)
     }
 
-    public func setDelegate<Delegate: CollapsibleSectionsFetchedResultsControllerDelegate>(_ delegate: Delegate?) where Delegate.FetchedObject == FetchedObject {
+    public func setDelegate<
+        Delegate: CollapsibleSectionsFetchedResultsControllerDelegate
+    >(
+        _ delegate: Delegate?
+    ) where Delegate.FetchedObject == FetchedObject {
         self.delegate = delegate.flatMap {
             CollapsibleSectionsFetchResultsDelegate($0)
         }

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -533,12 +533,12 @@ private extension FetchedResultsController {
         }
     }
 
-    func assign(
-        sortedObjects objects: some BidirectionalCollection<FetchedObject>,
+    func assign<C: BidirectionalCollection>(
+        sortedObjects objects: C,
         initialOrder: OrderedSet<FetchedObject.ID>,
         emitChanges: Bool,
         dropObjectsToInsert: Bool
-    ) {
+    ) where C.Element == FetchedObject {
         assert(Thread.isMainThread)
 
         if dropObjectsToInsert {
@@ -573,10 +573,10 @@ private extension FetchedResultsController {
         }
     }
 
-    func insert(
-        _ objects: some Collection<FetchedObject>,
+    func insert<C: Collection>(
+        _ objects: C,
         emitChanges: Bool = true
-    ) {
+    ) where C.Element == FetchedObject {
         // This is snapshotted because we're about to be off the main thread
         let fetchedObjectIDs = self.fetchedObjectIDs
 
@@ -591,11 +591,11 @@ private extension FetchedResultsController {
         insert(objects, fetchedObjectIDs: fetchedObjectIDs, emitChanges: emitChanges)
     }
 
-    private func insert(
-        _ objects: some Collection<FetchedObject>,
+    private func insert<C: Collection>(
+        _ objects: C,
         fetchedObjectIDs: OrderedSet<FetchedObject.ID>,
         emitChanges: Bool = true
-    ) {
+    ) where C.Element == FetchedObject {
         let initialOrder = OrderedSet(objects.map(\.id))
 
         let fetchOrder = fetchedObjectIDs.union(initialOrder)
@@ -629,11 +629,11 @@ private extension FetchedResultsController {
         }
     }
 
-    private func insert(
-        sortedObjects objects: some BidirectionalCollection<FetchedObject>,
+    private func insert<C: BidirectionalCollection>(
+        sortedObjects objects: C,
         initialOrder: OrderedSet<FetchedObject.ID>,
         emitChanges: Bool = true
-    ) {
+    ) where C.Element == FetchedObject {
         assert(Thread.isMainThread)
 
         performChanges(emitChanges: emitChanges) {
@@ -658,10 +658,10 @@ private extension FetchedResultsController {
         CWLogVerbose("Inserted \(objects.count) objects")
     }
 
-    func reload(
-        _ objects: some Collection<FetchedObject>,
+    func reload<C: Collection>(
+        _ objects: C,
         emitChanges: Bool = true
-    ) {
+    ) where C.Element == FetchedObject {
         var objectPaths: [FetchedObject: IndexPath] = [:]
         for object in objects {
             guard let indexPath = indexPath(for: object) else {

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -533,12 +533,12 @@ private extension FetchedResultsController {
         }
     }
 
-    func assign<C: BidirectionalCollection>(
-        sortedObjects objects: C,
+    func assign(
+        sortedObjects objects: some BidirectionalCollection<FetchedObject>,
         initialOrder: OrderedSet<FetchedObject.ID>,
         emitChanges: Bool,
         dropObjectsToInsert: Bool
-    ) where C.Element == FetchedObject {
+    ) {
         assert(Thread.isMainThread)
 
         if dropObjectsToInsert {
@@ -573,7 +573,10 @@ private extension FetchedResultsController {
         }
     }
 
-    func insert<C: Collection>(_ objects: C, emitChanges: Bool = true) where C.Iterator.Element == FetchedObject {
+    func insert(
+        _ objects: some Collection<FetchedObject>,
+        emitChanges: Bool = true
+    ) {
         // This is snapshotted because we're about to be off the main thread
         let fetchedObjectIDs = self.fetchedObjectIDs
 
@@ -588,11 +591,11 @@ private extension FetchedResultsController {
         insert(objects, fetchedObjectIDs: fetchedObjectIDs, emitChanges: emitChanges)
     }
 
-    private func insert<C: Collection>(
-        _ objects: C,
+    private func insert(
+        _ objects: some Collection<FetchedObject>,
         fetchedObjectIDs: OrderedSet<FetchedObject.ID>,
         emitChanges: Bool = true
-    ) where C.Iterator.Element == FetchedObject {
+    ) {
         let initialOrder = OrderedSet(objects.map(\.id))
 
         let fetchOrder = fetchedObjectIDs.union(initialOrder)
@@ -626,11 +629,11 @@ private extension FetchedResultsController {
         }
     }
 
-    private func insert<C: BidirectionalCollection>(
-        sortedObjects objects: C,
+    private func insert(
+        sortedObjects objects: some BidirectionalCollection<FetchedObject>,
         initialOrder: OrderedSet<FetchedObject.ID>,
         emitChanges: Bool = true
-    ) where C.Element == FetchedObject {
+    ) {
         assert(Thread.isMainThread)
 
         performChanges(emitChanges: emitChanges) {
@@ -655,7 +658,10 @@ private extension FetchedResultsController {
         CWLogVerbose("Inserted \(objects.count) objects")
     }
 
-    func reload<C: Collection>(_ objects: C, emitChanges: Bool = true) where C.Iterator.Element == FetchedObject {
+    func reload(
+        _ objects: some Collection<FetchedObject>,
+        emitChanges: Bool = true
+    ) {
         var objectPaths: [FetchedObject: IndexPath] = [:]
         for object in objects {
             guard let indexPath = indexPath(for: object) else {

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -45,7 +45,7 @@ public enum FetchedResultsChange<Location: Equatable>: Equatable {
     }
 }
 
-public protocol FetchedResultsControllerDelegate: AnyObject {
+public protocol FetchedResultsControllerDelegate<FetchedObject>: AnyObject {
     associatedtype FetchedObject: FetchableObject
 
     func controllerWillChangeContent(_ controller: FetchedResultsController<FetchedObject>)

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -193,7 +193,7 @@ public extension FetchedResultsControllerProtocol {
 // MARK: - Binary Search
 
 extension RandomAccessCollection where Index: Strideable {
-    func binarySearch(matching: (Iterator.Element) -> Bool) -> Self.Index {
+    func binarySearch(matching: (Element) -> Bool) -> Self.Index {
         var lowerIndex = startIndex
         var upperIndex = endIndex
 

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -19,8 +19,9 @@ public protocol DoublyObservableObject: ObservableObject {
     var objectDidChange: ObjectDidChangePublisher { get }
 }
 
-public protocol FetchedResultsControllerProtocol: DoublyObservableObject {
+public protocol FetchedResultsControllerProtocol<FetchedObject>: DoublyObservableObject {
     associatedtype FetchedObject: FetchableObject
+
     typealias SectionNameKeyPath = KeyPath<FetchedObject, String>
     typealias Section = FetchedResultsSection<FetchedObject>
 

--- a/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
@@ -156,7 +156,11 @@ extension PausableFetchedResultsController: FetchedResultsControllerProtocol {
         return sectionsSnapshot ?? controller.sections
     }
 
-    public func setDelegate<Delegate: PausableFetchedResultsControllerDelegate>(_ delegate: Delegate?) where Delegate.FetchedObject == FetchedObject {
+    public func setDelegate<
+        Delegate: PausableFetchedResultsControllerDelegate
+    >(
+        _ delegate: Delegate?
+    ) where Delegate.FetchedObject == FetchedObject {
         self.delegate = delegate.flatMap {
             PausableFetchResultsDelegate($0, pausableController: self)
         }

--- a/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Combine
 
-public protocol PausableFetchedResultsControllerDelegate: AnyObject {
+public protocol PausableFetchedResultsControllerDelegate<FetchedObject>: AnyObject {
     associatedtype FetchedObject: FetchableObject
 
     func controllerWillChangeContent(_ controller: PausableFetchedResultsController<FetchedObject>)

--- a/FetchRequests/Sources/FetchableObject.swift
+++ b/FetchRequests/Sources/FetchableObject.swift
@@ -12,7 +12,7 @@ import Foundation
 public typealias FetchableObject = NSObject & FetchableObjectProtocol
 
 /// A class of types whose instances hold raw data of that entity
-public protocol RawDataRepresentable {
+public protocol RawDataRepresentable<RawData> {
     associatedtype RawData
 
     /// Initialize a fetchable object from raw data

--- a/FetchRequests/Sources/OrderedSetCompat.swift
+++ b/FetchRequests/Sources/OrderedSetCompat.swift
@@ -31,7 +31,7 @@ struct OrderedSet<Element: Hashable> {
         indexed = [:]
     }
 
-    init(_ sequence: some Sequence<Element>) {
+    init<S: Sequence>(_ sequence: S) where S.Element == Element {
         self.init()
         sequence.forEach { insert($0) }
     }
@@ -134,25 +134,33 @@ extension OrderedSet: SetAlgebra {
 
     // Copies
 
-    func union(_ other: some Sequence<Element>) -> OrderedSet<Element> {
+    func union<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
         var copy = self
         copy.formUnion(other)
         return copy
     }
 
-    func intersection(_ other: some Sequence<Element>) -> OrderedSet<Element> {
+    func intersection<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
         var copy = self
         copy.formIntersection(other)
         return copy
     }
 
-    func symmetricDifference(_ other: some Sequence<Element>) -> OrderedSet<Element>  {
+    func symmetricDifference<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
         var copy = self
         copy.formSymmetricDifference(other)
         return copy
     }
 
-    func subtracting(_ other: some Sequence<Element>) -> OrderedSet<Element>  {
+    func subtracting<S: Sequence>(
+        _ other: S
+    ) -> OrderedSet<Element> where S.Element == Element {
         var copy = self
         copy.subtract(other)
         return copy
@@ -160,7 +168,9 @@ extension OrderedSet: SetAlgebra {
 
     // Mutating
 
-    mutating func formUnion(_ other: some Sequence<Element>) {
+    mutating func formUnion<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
         let maxCapacity = elements.count + other.underestimatedCount
         if capacity < maxCapacity {
             reserveCapacity(maxCapacity)
@@ -169,13 +179,17 @@ extension OrderedSet: SetAlgebra {
         other.forEach { insert($0) }
     }
 
-    mutating func formIntersection(_ other: some Sequence<Element>) {
+    mutating func formIntersection<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
         unordered.formIntersection(other)
         let newElements = elements.filter { !unordered.contains($0) }
         elements = newElements
     }
 
-    mutating func formSymmetricDifference(_ other: some Sequence<Element>) {
+    mutating func formSymmetricDifference<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
         let maxCapacity = elements.count + other.underestimatedCount
         if capacity < maxCapacity {
             reserveCapacity(maxCapacity)
@@ -190,7 +204,9 @@ extension OrderedSet: SetAlgebra {
         }
     }
 
-    mutating func subtract(_ other: some Sequence<Element>) {
+    mutating func subtract<S: Sequence>(
+        _ other: S
+    ) where S.Element == Element {
         unordered.subtract(other)
         let newElements = elements.filter { !unordered.contains($0) }
         elements = newElements

--- a/FetchRequests/Sources/OrderedSetCompat.swift
+++ b/FetchRequests/Sources/OrderedSetCompat.swift
@@ -31,7 +31,7 @@ struct OrderedSet<Element: Hashable> {
         indexed = [:]
     }
 
-    init<S: Sequence>(_ sequence: S) where S.Element == Element {
+    init(_ sequence: some Sequence<Element>) {
         self.init()
         sequence.forEach { insert($0) }
     }
@@ -134,33 +134,25 @@ extension OrderedSet: SetAlgebra {
 
     // Copies
 
-    func union<S: Sequence>(
-        _ other: S
-    ) -> OrderedSet<Element> where S.Element == Element {
+    func union(_ other: some Sequence<Element>) -> OrderedSet<Element> {
         var copy = self
         copy.formUnion(other)
         return copy
     }
 
-    func intersection<S: Sequence>(
-        _ other: S
-    ) -> OrderedSet<Element> where S.Element == Element {
+    func intersection(_ other: some Sequence<Element>) -> OrderedSet<Element> {
         var copy = self
         copy.formIntersection(other)
         return copy
     }
 
-    func symmetricDifference<S: Sequence>(
-        _ other: S
-    ) -> OrderedSet<Element> where S.Element == Element {
+    func symmetricDifference(_ other: some Sequence<Element>) -> OrderedSet<Element>  {
         var copy = self
         copy.formSymmetricDifference(other)
         return copy
     }
 
-    func subtracting<S: Sequence>(
-        _ other: S
-    ) -> OrderedSet<Element> where S.Element == Element {
+    func subtracting(_ other: some Sequence<Element>) -> OrderedSet<Element>  {
         var copy = self
         copy.subtract(other)
         return copy
@@ -168,9 +160,7 @@ extension OrderedSet: SetAlgebra {
 
     // Mutating
 
-    mutating func formUnion<S: Sequence>(
-        _ other: S
-    ) where S.Element == Element {
+    mutating func formUnion(_ other: some Sequence<Element>) {
         let maxCapacity = elements.count + other.underestimatedCount
         if capacity < maxCapacity {
             reserveCapacity(maxCapacity)
@@ -179,17 +169,13 @@ extension OrderedSet: SetAlgebra {
         other.forEach { insert($0) }
     }
 
-    mutating func formIntersection<S: Sequence>(
-        _ other: S
-    ) where S.Element == Element {
+    mutating func formIntersection(_ other: some Sequence<Element>) {
         unordered.formIntersection(other)
         let newElements = elements.filter { !unordered.contains($0) }
         elements = newElements
     }
 
-    mutating func formSymmetricDifference<S: Sequence>(
-        _ other: S
-    ) where S.Element == Element {
+    mutating func formSymmetricDifference(_ other: some Sequence<Element>) {
         let maxCapacity = elements.count + other.underestimatedCount
         if capacity < maxCapacity {
             reserveCapacity(maxCapacity)
@@ -204,9 +190,7 @@ extension OrderedSet: SetAlgebra {
         }
     }
 
-    mutating func subtract<S: Sequence>(
-        _ other: S
-    ) where S.Element == Element {
+    mutating func subtract(_ other: some Sequence<Element>) {
         unordered.subtract(other)
         let newElements = elements.filter { !unordered.contains($0) }
         elements = newElements

--- a/FetchRequests/Sources/Requests/FetchDefinition.swift
+++ b/FetchRequests/Sources/Requests/FetchDefinition.swift
@@ -20,13 +20,16 @@ public class FetchDefinition<FetchedObject: FetchableObject> {
 
     internal let associationsByKeyPath: [FetchRequestAssociation<FetchedObject>.AssociationKeyPath: FetchRequestAssociation<FetchedObject>]
 
-    public init<VoidToken: ObservableToken, DataToken: ObservableToken>(
+    public init<
+        VoidToken: ObservableToken<Void>,
+        DataToken: ObservableToken<FetchedObject.RawData>
+    >(
         request: @escaping Request,
         objectCreationToken: DataToken,
         creationInclusionCheck: @escaping CreationInclusionCheck = { _ in true },
         associations: [FetchRequestAssociation<FetchedObject>] = [],
         dataResetTokens: [VoidToken] = []
-    ) where VoidToken.Parameter == Void, DataToken.Parameter == FetchedObject.RawData {
+    ) {
         self.request = request
         self.objectCreationToken = FetchRequestObservableToken(token: objectCreationToken)
         self.creationInclusionCheck = creationInclusionCheck

--- a/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
+++ b/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
@@ -16,14 +16,17 @@ public class PaginatingFetchDefinition<FetchedObject: FetchableObject>: FetchDef
 
     internal let paginationRequest: PaginationRequest
 
-    public init<VoidToken: ObservableToken, DataToken: ObservableToken>(
+    public init<
+        VoidToken: ObservableToken<Void>,
+        DataToken: ObservableToken<FetchedObject.RawData>
+    >(
         request: @escaping Request,
         paginationRequest: @escaping PaginationRequest,
         objectCreationToken: DataToken,
         creationInclusionCheck: @escaping CreationInclusionCheck = { _ in true },
         associations: [FetchRequestAssociation<FetchedObject>] = [],
         dataResetTokens: [VoidToken] = []
-    ) where VoidToken.Parameter == Void, DataToken.Parameter == FetchedObject.RawData {
+    ) {
         self.paginationRequest = paginationRequest
         super.init(
             request: request,


### PR DESCRIPTION
# What

Change protocols to be generic

# Why

Simplify call sites / readability

# How

This adds "primary" associated types for protocols where appropriate.
It then removes where clauses that can be defined via generic signatures.