### PR TITLE
Json literal type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Released on TKTKTK
 
 * Requires Swift 5.7
 * Protocols define their primary associated types
-* JSON literal arrays and dictionaries now must be strongly typed
+* JSON literal arrays and dictionaries now must be strongly typed via the `JSONConvertible` protocol
 
 ## [4.0.4](https://github.com/square/FetchRequests/releases/tag/4.0.4)
 Released on 2022-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Released on TKTKTK
 
 * Requires Swift 5.7
 * Protocols define their primary associated types
+* JSON literal arrays and dictionaries now must be strongly typed
 
 ## [4.0.4](https://github.com/square/FetchRequests/releases/tag/4.0.4)
 Released on 2022-08-30

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -379,38 +379,38 @@ extension JSON: ExpressibleByDictionaryLiteral {
         let data: [String: JSON] = elements.reduce(into: [:]) { memo, element in
             memo[element.0] = element.1.jsonRepresentation()
         }
-        self = .dictionary(data)
+        self.init(data)
     }
 }
 
 extension JSON: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: JSONConvertible...) {
         let data: [JSON] = elements.map { $0.jsonRepresentation() }
-        self = .array(data)
+        self.init(data)
     }
 }
 
 extension JSON: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
-        self = .string(value)
+        self.init(value)
     }
 }
 
 extension JSON: ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) {
-        self = .bool(value)
+        self.init(value)
     }
 }
 
 extension JSON: ExpressibleByFloatLiteral {
     public init(floatLiteral value: Double) {
-        self = .number(NSNumber(value: value))
+        self.init(value)
     }
 }
 
 extension JSON: ExpressibleByIntegerLiteral {
     public init(integerLiteral value: Int) {
-        self = .number(NSNumber(value: value))
+        self.init(value)
     }
 }
 

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -22,31 +22,19 @@ public enum JSON {
     public init?(_ value: Any) {
         if let value = value as? Data {
             self.init(data: value)
-        } else if let value = value as? JSON {
-            self = value
-        } else if let value = value as? String {
-            self = .string(value)
-        } else if let value = value as? NSNumber, value.isBool {
-            self = .bool(value.boolValue)
-        } else if let value = value as? NSNumber {
-            self = .number(value)
-        } else if let value = value as? [JSON] {
-            self = .array(value.map(\.object))
-        } else if let value = value as? [Any] {
-            self = .array(value)
-        } else if let value = value as? [String: JSON] {
-            self = .dictionary(
-                value.reduce(into: [:]) { memo, kvp in
-                    memo[kvp.key] = kvp.value.object
-                }
-            )
+        } else if let value = value as? JSONConvertible {
+            self.init(value)
         } else if let value = value as? [String: Any] {
             self = .dictionary(value)
-        } else if let _ = value as? NSNull {
-            self = .null
+        } else if let value = value as? [Any] {
+            self = .array(value)
         } else {
             return nil
         }
+    }
+
+    public init(_ value: JSONConvertible) {
+        self = value.jsonRepresentation()
     }
 
     public init?(
@@ -385,17 +373,17 @@ extension JSON: Collection {
 // MARK: - Literals
 
 extension JSON: ExpressibleByDictionaryLiteral {
-    public init(dictionaryLiteral elements: (String, Any)...) {
-        let data: [String: Any] = elements.reduce(into: [:]) { memo, element in
-            memo[element.0] = element.1
+    public init(dictionaryLiteral elements: (String, JSONConvertible)...) {
+        let data: [String: JSON] = elements.reduce(into: [:]) { memo, element in
+            memo[element.0] = element.1.jsonRepresentation()
         }
         self = .dictionary(data)
     }
 }
 
 extension JSON: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Any...) {
-        let data: [Any] = elements
+    public init(arrayLiteral elements: JSONConvertible...) {
+        let data: [JSON] = elements.map { $0.jsonRepresentation() }
         self = .array(data)
     }
 }
@@ -499,7 +487,7 @@ extension JSON: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
-        let object: Any
+        let object: JSONConvertible
 
         if container.decodeNil() {
             object = NSNull()
@@ -511,57 +499,34 @@ extension JSON: Decodable {
             object = array
         } else if let dictionary = try? container.decode([String: JSON].self) {
             object = dictionary
+        } else if let int = try? container.decode(Int64.self) {
+            object = int
+        } else if let int = try? container.decode(Int32.self) {
+            object = int
+        } else if let int = try? container.decode(Int16.self) {
+            object = int
+        } else if let int = try? container.decode(Int8.self) {
+            object = int
+        } else if let int = try? container.decode(Int.self) {
+            object = int
+        } else if let int = try? container.decode(UInt64.self) {
+            object = int
+        } else if let int = try? container.decode(UInt32.self) {
+            object = int
+        } else if let int = try? container.decode(UInt16.self) {
+            object = int
+        } else if let int = try? container.decode(UInt8.self) {
+            object = int
+        } else if let int = try? container.decode(UInt.self) {
+            object = int
+        } else if let double = try? container.decode(Double.self) {
+            object = double
+        } else if let float = try? container.decode(Float.self) {
+            object = float
         } else {
-            var signedNumber: NSNumber? {
-                if let int = try? container.decode(Int64.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(Int32.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(Int16.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(Int8.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(Int.self) {
-                    return NSNumber(value: int)
-                } else {
-                    return nil
-                }
-            }
-            var unsignedNumber: NSNumber? {
-                if let int = try? container.decode(UInt64.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(UInt32.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(UInt16.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(UInt8.self) {
-                    return NSNumber(value: int)
-                } else if let int = try? container.decode(UInt.self) {
-                    return NSNumber(value: int)
-                } else {
-                    return nil
-                }
-            }
-            var floatingPointNumber: NSNumber? {
-                if let double = try? container.decode(Double.self) {
-                    return NSNumber(value: double)
-                } else if let float = try? container.decode(Float.self) {
-                    return NSNumber(value: float)
-                } else {
-                    return nil
-                }
-            }
-
-            guard let number = signedNumber ?? unsignedNumber ?? floatingPointNumber else {
-                throw JSONError.invalidContent
-            }
-            object = number
-        }
-
-        guard let data = JSON(object) else {
             throw JSONError.invalidContent
         }
-        self = data
+        self = object.jsonRepresentation()
     }
 }
 
@@ -593,5 +558,133 @@ private extension NSNumber {
         case integer
         case floatingPoint
         case boolean
+    }
+}
+
+// MARK: - JSONConvertible
+
+public protocol JSONConvertible {
+    func jsonRepresentation() -> JSON
+}
+
+extension JSON: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return self
+    }
+}
+
+extension Array: JSONConvertible where Element: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .array(map { $0.jsonRepresentation().object })
+    }
+}
+
+extension Dictionary: JSONConvertible where Key == String, Value: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .dictionary(
+            reduce(into: [:]) { memo, kvp in
+                memo[kvp.key] = kvp.value.jsonRepresentation().object
+            }
+        )
+    }
+}
+
+extension String: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .string(self)
+    }
+}
+
+extension NSNull: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .null
+    }
+}
+
+extension NSNumber: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        if self.isBool {
+            return .bool(boolValue)
+        } else {
+            return .number(self)
+        }
+    }
+}
+
+extension Bool: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .bool(self)
+    }
+}
+
+extension Int64: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension Int32: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension Int16: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension Int8: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension Int: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension UInt64: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension UInt32: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension UInt16: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension UInt8: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension UInt: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension Double: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
+    }
+}
+
+extension Float: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .number(NSNumber(value: self))
     }
 }

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -376,17 +376,19 @@ extension JSON: Collection {
 
 extension JSON: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (String, JSONConvertible)...) {
-        let data: [String: JSON] = elements.reduce(into: [:]) { memo, element in
-            memo[element.0] = element.1.jsonRepresentation()
+        // This should be consistent with [String: JSONConvertible].jsonRepresentation()
+        let data: [String: Any] = elements.reduce(into: [:]) { memo, element in
+            memo[element.0] = element.1.jsonRepresentation().object
         }
-        self.init(data)
+        self = .dictionary(data)
     }
 }
 
 extension JSON: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: JSONConvertible...) {
-        let data: [JSON] = elements.map { $0.jsonRepresentation() }
-        self.init(data)
+        // This should be consistent with [JSONConvertible].jsonRepresentation()
+        let data: [Any] = elements.map { $0.jsonRepresentation().object }
+        self = .array(data)
     }
 }
 

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -597,6 +597,12 @@ extension String: JSONConvertible {
     }
 }
 
+extension NSString: JSONConvertible {
+    public func jsonRepresentation() -> JSON {
+        return .string(self as String)
+    }
+}
+
 extension NSNull: JSONConvertible {
     public func jsonRepresentation() -> JSON {
         return .null

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -577,17 +577,17 @@ extension JSON: JSONConvertible {
     }
 }
 
-extension [JSON]: JSONConvertible {
+extension Array: JSONConvertible where Element: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .array(map(\.object))
+        return .array(map { $0.jsonRepresentation().object })
     }
 }
 
-extension [String: JSON]: JSONConvertible {
+extension Dictionary: JSONConvertible where Key == String, Value: JSONConvertible {
     public func jsonRepresentation() -> JSON {
         return .dictionary(
             reduce(into: [:]) { memo, kvp in
-                memo[kvp.key] = kvp.value.object
+                memo[kvp.key] = kvp.value.jsonRepresentation().object
             }
         )
     }

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -25,8 +25,10 @@ public enum JSON {
         } else if let value = value as? JSONConvertible {
             self.init(value)
         } else if let value = value as? [String: Any] {
+            // This intentionally does not deeply evaluate child values
             self = .dictionary(value)
         } else if let value = value as? [Any] {
+            // This intentionally does not deeply evaluate child values
             self = .array(value)
         } else {
             return nil
@@ -573,17 +575,17 @@ extension JSON: JSONConvertible {
     }
 }
 
-extension Array: JSONConvertible where Element: JSONConvertible {
+extension [JSON]: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .array(map { $0.jsonRepresentation().object })
+        return .array(map(\.object))
     }
 }
 
-extension Dictionary: JSONConvertible where Key == String, Value: JSONConvertible {
+extension [String: JSON]: JSONConvertible {
     public func jsonRepresentation() -> JSON {
         return .dictionary(
             reduce(into: [:]) { memo, kvp in
-                memo[kvp.key] = kvp.value.jsonRepresentation().object
+                memo[kvp.key] = kvp.value.object
             }
         )
     }

--- a/FetchRequests/Tests/Models/JSONTestCase.swift
+++ b/FetchRequests/Tests/Models/JSONTestCase.swift
@@ -112,6 +112,18 @@ extension JSONTestCase {
         XCTAssertEqual(dictRepresentable.dictionary as NSDictionary?, dict as NSDictionary)
         XCTAssertEqual(dictInit?.dictionary as NSDictionary?, dict as NSDictionary)
     }
+
+    func testConvertible() {
+        let myValue: UInt64 = 1
+
+        let jsonArray: JSON = [myValue]
+        let jsonDictionary: JSON = [
+            "key": [myValue],
+        ]
+
+        XCTAssertEqual(jsonArray[0], myValue.jsonRepresentation())
+        XCTAssertEqual(jsonDictionary.key?[0], myValue.jsonRepresentation())
+    }
 }
 
 // MARK: - Subscripts

--- a/FetchRequests/Tests/Models/JSONTestCase.swift
+++ b/FetchRequests/Tests/Models/JSONTestCase.swift
@@ -39,7 +39,7 @@ extension JSONTestCase {
 
         XCTAssertTrue(enumValue.bool ?? false)
         XCTAssertTrue(boolRepresentable.bool ?? false)
-        XCTAssertTrue(nsnumberBoolInit?.bool ?? false)
+        XCTAssertTrue(nsnumberBoolInit.bool ?? false)
         XCTAssertEqual(enumValue, nsnumberBoolInit)
         XCTAssertEqual(enumValue, boolRepresentable)
         XCTAssertNotEqual(nsnumberBoolInit, nsnumberNumberInit)
@@ -84,7 +84,7 @@ extension JSONTestCase {
         XCTAssertEqual(enumValue, stringRepresentable)
         XCTAssertEqual(enumValue.string, string)
         XCTAssertEqual(stringRepresentable.string, string)
-        XCTAssertEqual(stringInit?.string, string)
+        XCTAssertEqual(stringInit.string, string)
     }
 
     func testArray() {
@@ -411,6 +411,7 @@ extension JSONTestCase {
     func testJsonNSObjectForBoxedJSON() {
         let dict = NSDictionary(dictionary: ["name": "Alexa"])
         let boxed = BoxedJSON(__object: dict)
-        XCTAssertTrue(boxed?.json.name?.string == "Alexa")
+        XCTAssertNotNil(boxed)
+        XCTAssertEqual(boxed?.json.name?.string, "Alexa")
     }
 }

--- a/FetchRequests/Tests/Models/JSONTestCase.swift
+++ b/FetchRequests/Tests/Models/JSONTestCase.swift
@@ -119,6 +119,7 @@ extension JSONTestCase {
         let jsonArray: JSON = [myValue]
         let jsonDictionary: JSON = [
             "key": [myValue],
+            "key2": jsonArray,
         ]
 
         XCTAssertEqual(jsonArray[0], myValue.jsonRepresentation())


### PR DESCRIPTION
This changes the handling of JSON literals to force dictionary and array values to conform to a new `JSONConvertible` protocol.
This is also adds support for a non-optional initializer since it's known to safely convert.

The resulting JSON objects will be strongly typed and evaluated by the compiler.
They will have more guarantees than something like `JSON([String: Any])` which lazily evaluates its children.

### Performance

It will have a _minor_ impact on performance in so far as the compiler can choose to do one of several things:
```swift
let n: JSON = [
    "simple": [1, 2, 3],
    "complex": [1, "a"],
]
```

The simple array could be compiled as:
* [Int]
* [JSON]
* JSON

The complex array could be
* [any JSONConvertible]
* [JSON]
* JSON

Depending on what the compiler decides to create, it may cost need it iterate and convert an array of primitives into a usable actual object.
This would cost extra allocations and runtime performance.

As long as we aren't creating _massive_ JSON payloads, this shouldn't really be a problem.
Further, you could help the compiler by doing `[1, "a"] as JSON`

The alternative would be for Dictionary and Array to only conform to `JSONConvertible` if their values are JSON (as opposed to `JSONConvertible`.
That would mean that literal JSON types (at the second level) would only accept `JSON` instead of `JSONConvertible`.
That would force each tier of the structure to proactively convert to JSON; however, that means you can't add non-literal values to your array / dictionary.

You would be forced to do something like:
```swift
let myValue: UInt64 = 1

let n: JSON = [
    "simple": [1, 2, 3],
    "complex": [1, "a"],
    "extra": [myValue] as JSON,
]
```