### PR TITLE
Stricter association constraints

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -7,9 +7,13 @@
 
 --rules blankLineAfterImports
 --rules braces
+--rules conditionalAssignment
 --rules duplicateImports
 --rules elseOnSameLine
 --rules genericExtensions
+
+--rules hoistAwait
+--rules hoistTry
 
 --rules indent
   --indent 4
@@ -20,11 +24,14 @@
 --rules leadingDelimiters
 --rules linebreakAtEndOfFile
 
+--rules redundantClosure
 --rules redundantFileprivate
 --rules redundantGet
 --rules redundantInit
 --rules redundantOptionalBinding
 --rules redundantParens
+--rules redundantPattern
+--rules redundantReturn
 --rules redundantVoidReturnType
 --rules semicolons
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,11 +5,16 @@ disabled_rules:
   - opening_brace
   - unused_closure_parameter
   - unused_optional_binding
+  # Nice to haves
   - cyclomatic_complexity
   - function_body_length
   - line_length
-opt_in_rules:
+analyzer_rules:
   - capture_variable
+  - unused_declaration
+  - unused_import
+opt_in_rules:
+  - balanced_xctest_lifecycle
   - closure_spacing
   - closure_end_indentation
   - collection_alignment
@@ -55,14 +60,15 @@ opt_in_rules:
   - redundant_nil_coalescing
   - redundant_objc_attribute
   - self_binding
+  - single_test_class
+  - shorthand_optional_binding
   - sorted_first_last
   - static_operator
   - strong_iboutlet
+  - test_case_accessibility
   - toggle_bool
   - trailing_closure
   - untyped_error_in_catch
-  - unused_import
-  - unused_declaration
   - vertical_parameter_alignment_on_call
   - vertical_whitespace_between_cases
   - vertical_whitespace_opening_braces
@@ -94,7 +100,7 @@ large_tuple:
   warning: 3
   error: 4
 deployment_target:
-  iOS_deployment_target: 13
-  tvOS_deployment_target: 13
-  watchOS_deployment_target: 6
-  macOS_deployment_target: 10.15
+  iOS_deployment_target: 14
+  tvOS_deployment_target: 14
+  watchOS_deployment_target: 7
+  macOS_deployment_target: 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 All notable changes to this project will be documented in this file.
 `FetchRequests` adheres to [Semantic Versioning](https://semver.org/).
 
+## [6.0](https://github.com/square/FetchRequests/releases/tag/5.0.0)
+Released on 2023-04-05
+
+* Requires Swift 5.8
+* FetchableEntityID's async methods are now marked as @MainActor
+* Association Request completion handlers are now marked as @MainActor
+    * Previously the handler would immediately bounce to the main thread if needed
+* Bump deployment targets:
+    * iOS, tvOS, Catalyst: v14
+    * watchOS v7
+    * macOS v11
+
 ## [5.0](https://github.com/square/FetchRequests/releases/tag/5.0.0)
 Released on 2022-10-25
 

--- a/Example/iOS-Example/Atomic.swift
+++ b/Example/iOS-Example/Atomic.swift
@@ -19,7 +19,7 @@ struct Atomic<Value> {
 
     var wrappedValue: Value {
         get {
-            return queue.sync { storage }
+            queue.sync { storage }
         }
         set {
             queue.sync(flags: .barrier) { storage = newValue }
@@ -27,7 +27,7 @@ struct Atomic<Value> {
     }
 
     mutating func mutate(_ mutation: (inout Value) throws -> Void) rethrows {
-        return try queue.sync(flags: .barrier) {
+        try queue.sync(flags: .barrier) {
             try mutation(&storage)
         }
     }

--- a/Example/iOS-Example/Model+Persistence.swift
+++ b/Example/iOS-Example/Model+Persistence.swift
@@ -21,19 +21,19 @@ private let decoder = JSONDecoder()
 
 extension Model {
     func rawObjectEventUpdated() -> Notification.Name {
-        return Notification.Name("\(NSStringFromClass(type(of: self))).rawObjectEventUpdated.\(id)")
+        Notification.Name("\(NSStringFromClass(type(of: self))).rawObjectEventUpdated.\(id)")
     }
 
     class func objectWasCreated() -> Notification.Name {
-        return Notification.Name("\(NSStringFromClass(self)).objectWasCreated")
+        Notification.Name("\(NSStringFromClass(self)).objectWasCreated")
     }
 
     class func objectWasDeleted() -> Notification.Name {
-        return Notification.Name("\(NSStringFromClass(self)).objectWasDeleted")
+        Notification.Name("\(NSStringFromClass(self)).objectWasDeleted")
     }
 
     class func dataWasCleared() -> Notification.Name {
-        return Notification.Name("\(NSStringFromClass(self)).dataWasCleared")
+        Notification.Name("\(NSStringFromClass(self)).dataWasCleared")
     }
 }
 
@@ -125,7 +125,7 @@ extension Model {
 
 extension NSObjectProtocol where Self: Model {
     static func fetchAll() -> [Self] {
-        return storage.values.lazy.compactMap { value in
+        storage.values.lazy.compactMap { value in
             value as? Data
         }.compactMap { data in
             try? decoder.decode(Model.RawData.self, from: data)
@@ -135,7 +135,7 @@ extension NSObjectProtocol where Self: Model {
     }
 
     static func fetch(byID id: Model.ID) -> Self? {
-        return storage[id].flatMap { value in
+        storage[id].flatMap { value in
             value as? Data
         }.flatMap { data in
             try? decoder.decode(Model.RawData.self, from: data)

--- a/Example/iOS-Example/Model.swift
+++ b/Example/iOS-Example/Model.swift
@@ -90,7 +90,7 @@ class Model: NSObject {
 
 extension Model: Identifiable {
     var id: ID {
-        return data.id
+        data.id
     }
 }
 
@@ -110,13 +110,13 @@ extension Model {
 
 extension Model: FetchableObjectProtocol {
     func observeDataChanges(_ handler: @escaping @MainActor () -> Void) -> InvalidatableToken {
-        return _data.observeChanges { change in
+        _data.observeChanges { change in
             handler()
         }
     }
 
     func observeIsDeletedChanges(_ handler: @escaping @MainActor () -> Void) -> InvalidatableToken {
-        return self.observe(\.isDeleted, options: [.old, .new]) { @MainActor(unsafe) object, change in
+        self.observe(\.isDeleted, options: [.old, .new]) { @MainActor(unsafe) object, change in
             guard let old = change.oldValue, let new = change.newValue, old != new else {
                 return
             }
@@ -125,7 +125,7 @@ extension Model: FetchableObjectProtocol {
     }
 
     static func entityID(from data: RawData) -> Model.ID? {
-        return data.id
+        data.id
     }
 
     func listenForUpdates() {

--- a/Example/iOS-Example/Observable.swift
+++ b/Example/iOS-Example/Observable.swift
@@ -48,7 +48,7 @@ class Observable<Value> {
 
 extension Observable where Value: Equatable {
     func observeChanges(handler: @escaping Handler) -> InvalidatableToken {
-        return observe { change in
+        observe { change in
             guard change.oldValue != change.newValue else {
                 return
             }

--- a/Example/iOS-Example/ViewController.swift
+++ b/Example/iOS-Example/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UITableViewController {
         }
 
         class var reuseIdentifier: String {
-            return NSStringFromClass(self)
+            NSStringFromClass(self)
         }
     }
 }
@@ -69,11 +69,11 @@ extension ViewController {
 
 extension ViewController {
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return controller.sections.count
+        controller.sections.count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return controller.sections[section].numberOfObjects
+        controller.sections[section].numberOfObjects
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/FetchRequests.podspec
+++ b/FetchRequests.podspec
@@ -1,16 +1,16 @@
 Pod::Spec.new do |s|
   s.name = 'FetchRequests'
-  s.version = '5.0.0'
+  s.version = '6.0.0'
   s.license = 'MIT'
   s.summary = 'NSFetchedResultsController inspired eventing'
   s.homepage = 'https://github.com/square/FetchRequests'
   s.authors = 'Square'
   s.source = { :git => 'https://github.com/square/FetchRequests.git', :tag => s.version }
 
-  ios_deployment_target = '13.0'
-  tvos_deployment_target = '13.0'
-  watchos_deployment_target = '6.0'
-  macos_deployment_target = '10.15'
+  ios_deployment_target = '14.0'
+  tvos_deployment_target = '14.0'
+  watchos_deployment_target = '7.0'
+  macos_deployment_target = '11'
 
   s.ios.deployment_target = ios_deployment_target
   s.tvos.deployment_target = tvos_deployment_target

--- a/FetchRequests/Sources/Associations/AssociatedValueReference.swift
+++ b/FetchRequests/Sources/Associations/AssociatedValueReference.swift
@@ -82,7 +82,7 @@ class AssociatedValueReference: NSObject {
     fileprivate var changeHandler: ChangeHandler?
 
     var canObserveCreation: Bool {
-        return creationObserver != nil
+        creationObserver != nil
     }
 
     init(

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -17,9 +17,9 @@ public enum AssociationReplacement<T> {
 /// Map an associated value's key to object
 public class FetchRequestAssociation<FetchedObject: FetchableObject> {
     /// Fetch associated values given a list of parent objects
-    public typealias AssocationRequestByParent<AssociatedEntity> = @MainActor (_ objects: [FetchedObject], _ completion: @escaping ([FetchedObject.ID: AssociatedEntity]) -> Void) -> Void
+    public typealias AssocationRequestByParent<AssociatedEntity> = @MainActor (_ objects: [FetchedObject], _ completion: @escaping @MainActor ([FetchedObject.ID: AssociatedEntity]) -> Void) -> Void
     /// Fetch associated values given a list of associated IDs
-    public typealias AssocationRequestByID<AssociatedEntityID: Hashable, AssociatedEntity> = @MainActor (_ objects: [AssociatedEntityID], _ completion: @escaping ([AssociatedEntity]) -> Void) -> Void
+    public typealias AssocationRequestByID<AssociatedEntityID: Hashable, AssociatedEntity> = @MainActor (_ objects: [AssociatedEntityID], _ completion: @escaping @MainActor ([AssociatedEntity]) -> Void) -> Void
     /// Event that represents the creation of an associated value object
     public typealias CreationObserved<Value, Comparison> = (Value?, Comparison) -> AssociationReplacement<Value>
     /// Start observing a source object

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -93,7 +93,7 @@ public extension FetchRequestAssociation {
             },
             referenceGenerator: { _ in AssociatedValueReference() },
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -117,7 +117,7 @@ public extension FetchRequestAssociation {
             },
             referenceGenerator: { _ in AssociatedValueReference() },
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -184,7 +184,7 @@ public extension FetchRequestAssociation {
             },
             referenceGenerator: referenceGenerator,
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -247,7 +247,7 @@ public extension FetchRequestAssociation {
             },
             referenceGenerator: referenceGenerator,
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -387,7 +387,7 @@ public extension FetchRequestAssociation {
             request: rawRequest,
             referenceGenerator: referenceGenerator,
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -479,7 +479,7 @@ public extension FetchRequestAssociation {
             request: rawRequest,
             referenceGenerator: referenceGenerator,
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -607,7 +607,7 @@ public extension FetchRequestAssociation {
             request: rawRequest,
             referenceGenerator: referenceGenerator,
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -731,7 +731,7 @@ public extension FetchRequestAssociation {
             request: rawRequest,
             referenceGenerator: referenceGenerator,
             observeKeyPath: { object, changeHandler in
-                return object.observe(keyPath, options: [.old, .new]) { object, change in
+                object.observe(keyPath, options: [.old, .new]) { object, change in
                     guard change.oldValue != change.newValue else {
                         return
                     }
@@ -898,7 +898,7 @@ public extension FetchRequestAssociation {
 
 private extension Sequence {
     func associated<Key: Hashable>(by keySelector: (Element) throws -> Key) rethrows -> [Key: Element] {
-        return try reduce(into: [:]) { memo, element in
+        try reduce(into: [:]) { memo, element in
             let key = try keySelector(element)
             memo[key] = element
         }
@@ -907,6 +907,6 @@ private extension Sequence {
 
 private extension Sequence where Element: FetchableObjectProtocol {
     func createLookupTable() -> [Element.ID: Element] {
-        return self.associated(by: \.id)
+        self.associated(by: \.id)
     }
 }

--- a/FetchRequests/Sources/Associations/FetchableEntityID.swift
+++ b/FetchRequests/Sources/Associations/FetchableEntityID.swift
@@ -22,13 +22,13 @@ public protocol FetchableEntityID<FetchableEntity>: Hashable {
     )
     static func fetch(
         byIDs objectIDs: [Self],
-        completion: @escaping @MainActor ([FetchableEntity]
-    ) -> Void)
+        completion: @escaping @MainActor ([FetchableEntity]) -> Void
+    )
 }
 
 extension FetchableEntityID {
     static func fetch(byID objectID: Self) -> FetchableEntity? {
-        return self.fetch(byIDs: [objectID]).first
+        self.fetch(byIDs: [objectID]).first
     }
 
     static func fetch(

--- a/FetchRequests/Sources/Associations/FetchableEntityID.swift
+++ b/FetchRequests/Sources/Associations/FetchableEntityID.swift
@@ -16,8 +16,14 @@ public protocol FetchableEntityID<FetchableEntity>: Hashable {
     static func fetch(byID objectID: Self) -> FetchableEntity?
     static func fetch(byIDs objectIDs: [Self]) -> [FetchableEntity]
 
-    static func fetch(byID objectID: Self, completion: @escaping (FetchableEntity?) -> Void)
-    static func fetch(byIDs objectIDs: [Self], completion: @escaping ([FetchableEntity]) -> Void)
+    static func fetch(
+        byID objectID: Self,
+        completion: @escaping @MainActor (FetchableEntity?) -> Void
+    )
+    static func fetch(
+        byIDs objectIDs: [Self],
+        completion: @escaping @MainActor ([FetchableEntity]
+    ) -> Void)
 }
 
 extension FetchableEntityID {
@@ -25,7 +31,10 @@ extension FetchableEntityID {
         return self.fetch(byIDs: [objectID]).first
     }
 
-    static func fetch(byID objectID: Self, completion: @escaping (FetchableEntity?) -> Void) {
+    static func fetch(
+        byID objectID: Self,
+        completion: @escaping @MainActor (FetchableEntity?) -> Void
+    ) {
         self.fetch(byIDs: [objectID]) { objects in
             completion(objects.first)
         }

--- a/FetchRequests/Sources/Associations/ObservableToken.swift
+++ b/FetchRequests/Sources/Associations/ObservableToken.swift
@@ -154,7 +154,7 @@ internal class FetchRequestObservableToken<Parameter>: ObservableToken {
     private let _invalidate: () -> Void
 
     var isObserving: Bool {
-        return synchronized(self) {
+        synchronized(self) {
             unsafeIsObserving
         }
     }

--- a/FetchRequests/Sources/BoxedJSON.swift
+++ b/FetchRequests/Sources/BoxedJSON.swift
@@ -13,7 +13,7 @@ public class BoxedJSON: NSObject, NSSecureCoding {
     internal let json: JSON
 
     public static var supportsSecureCoding: Bool {
-        return true
+        true
     }
 
     public init(_ json: JSON) {
@@ -40,17 +40,17 @@ public class BoxedJSON: NSObject, NSSecureCoding {
 
     @objc
     public var object: Any {
-        return json.object
+        json.object
     }
 
     @objc
     public subscript(key: String) -> BoxedJSON? {
-        return json[key] as BoxedJSON?
+        json[key] as BoxedJSON?
     }
 
     @objc
     public subscript(offset: Int) -> BoxedJSON? {
-        return json[offset] as BoxedJSON?
+        json[offset] as BoxedJSON?
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
@@ -72,7 +72,7 @@ public class BoxedJSON: NSObject, NSSecureCoding {
 
 extension JSON: _ObjectiveCBridgeable {
     public func _bridgeToObjectiveC() -> BoxedJSON {
-        return BoxedJSON(self)
+        BoxedJSON(self)
     }
 
     public static func _forceBridgeFromObjectiveC(
@@ -98,3 +98,5 @@ extension JSON: _ObjectiveCBridgeable {
         return result!
     }
 }
+
+// swiftlint:enable identifier_name

--- a/FetchRequests/Sources/CollectionType+SortDescriptors.swift
+++ b/FetchRequests/Sources/CollectionType+SortDescriptors.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension Sequence where Element: NSSortDescriptor {
     var comparator: Comparator {
-        return { lhs, rhs in
+        { lhs, rhs in
             for sort in self {
                 let result = sort.compare(lhs, to: rhs)
                 guard result == .orderedSame else {
@@ -32,6 +32,6 @@ public extension Sequence where Element: NSObject {
     }
 
     private func sorted(by comparator: Comparator) -> [Element] {
-        return sorted { comparator($0, $1) == .orderedAscending }
+        sorted { comparator($0, $1) == .orderedAscending }
     }
 }

--- a/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/CollapsibleSectionsFetchedResultsController.swift
@@ -19,6 +19,7 @@ public struct SectionCollapseConfig: Equatable {
 }
 
 @MainActor
+// swiftlint:disable:next type_name
 public protocol CollapsibleSectionsFetchedResultsControllerDelegate<FetchedObject>: AnyObject {
     associatedtype FetchedObject: FetchableObject
 
@@ -45,19 +46,19 @@ public struct CollapsibleResultsSection<FetchedObject: FetchableObject>: Equatab
     let displayableObjects: [FetchedObject]
 
     public var allObjects: [FetchedObject] {
-        return section.objects
+        section.objects
     }
 
     public var id: String {
-        return section.id
+        section.id
     }
 
     public var name: String {
-        return section.name
+        section.name
     }
 
     public var numberOfDisplayableObjects: Int {
-        return displayableObjects.count
+        displayableObjects.count
     }
 
     init(
@@ -117,24 +118,24 @@ public class CollapsibleSectionsFetchedResultsController<FetchedObject: Fetchabl
 
     public var sections: [CollapsibleResultsSection<FetchedObject>] = []
     public var definition: FetchDefinition<FetchedObject> {
-        return fetchController.definition
+        fetchController.definition
     }
 
     public var sortDescriptors: [NSSortDescriptor] {
-        return fetchController.sortDescriptors
+        fetchController.sortDescriptors
     }
 
     public var fetchedObjects: [FetchedObject] {
-        return fetchController.fetchedObjects
+        fetchController.fetchedObjects
     }
 
     public var hasFetchedObjects: Bool {
-        return fetchController.hasFetchedObjects
+        fetchController.hasFetchedObjects
     }
 
     public var associatedFetchSize: Int {
         get {
-            return fetchController.associatedFetchSize
+            fetchController.associatedFetchSize
         }
         set {
             fetchController.associatedFetchSize = newValue
@@ -147,7 +148,7 @@ public class CollapsibleSectionsFetchedResultsController<FetchedObject: Fetchabl
         sectionNameKeyPath: SectionNameKeyPath? = nil,
         debounceInsertsAndReloads: Bool = true,
         initialSectionCollapseCheck: @escaping SectionCollapseCheck = { _ in false },
-        sectionConfigCheck: @escaping SectionCollapseConfigCheck = { _ in return nil }
+        sectionConfigCheck: @escaping SectionCollapseConfigCheck = { _ in nil }
     ) {
         fetchController = FetchedResultsController<FetchedObject>(
             definition: definition,
@@ -221,7 +222,7 @@ public extension CollapsibleSectionsFetchedResultsController {
     }
 
     func object(at indexPath: IndexPath) -> FetchedObject {
-        return sections[indexPath.section].displayableObjects[indexPath.item]
+        sections[indexPath.section].displayableObjects[indexPath.item]
     }
 
     func indexPath(for object: FetchedObject) -> IndexPath? {
@@ -291,7 +292,7 @@ extension CollapsibleSectionsFetchedResultsController: FetchedResultsControllerD
 
     public func controllerDidChangeContent(_ controller: FetchedResultsController<FetchedObject>) {
         let sectionsToNotify = collapsedSectionsModifiedDuringContentChange.filter { section in
-            return !changedSectionsDuringContentChange.contains(section) && !deletedSectionsDuringContentChange.contains(section)
+            !changedSectionsDuringContentChange.contains(section) && !deletedSectionsDuringContentChange.contains(section)
         }
         for sectionName in sectionsToNotify {
             guard let section = previousSectionsDuringContentChange.first(where: { $0.name == sectionName }),

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -156,11 +156,11 @@ public struct FetchedResultsSection<FetchedObject: FetchableObject>: Equatable, 
     public fileprivate(set) var objects: [FetchedObject]
 
     public var id: String {
-        return name
+        name
     }
 
     public var numberOfObjects: Int {
-        return objects.count
+        objects.count
     }
 
     public init(name: String, objects: [FetchedObject] = []) {
@@ -253,15 +253,13 @@ public class FetchedResultsController<FetchedObject: FetchableObject>: NSObject,
         }
     }
 
-    private lazy var context: Context<FetchedObject> = {
-        return Context { [weak self] keyPath, objectID in
-            guard let self else {
-                throw FetchedResultsError.objectNotFound
-            }
-
-            return try self.unsafeAssociatedValue(with: keyPath, forObjectID: objectID)
+    private lazy var context: Context<FetchedObject> = Context { [weak self] keyPath, objectID in
+        guard let self else {
+            throw FetchedResultsError.objectNotFound
         }
-    }()
+
+        return try self.unsafeAssociatedValue(with: keyPath, forObjectID: objectID)
+    }
 
     public init(
         definition: FetchDefinition<FetchedObject>,
@@ -373,7 +371,7 @@ public extension FetchedResultsController {
     }
 
     func indexPath(for object: FetchedObject) -> IndexPath? {
-        return indexPathsTable[object]
+        indexPathsTable[object]
     }
 
     @MainActor
@@ -1207,7 +1205,7 @@ private extension FetchedResultsController {
 
 internal extension FetchedResultsController {
     var listeningForInserts: Bool {
-        return definition.objectCreationToken.isObserving
+        definition.objectCreationToken.isObserving
     }
 }
 
@@ -1346,7 +1344,7 @@ private class Context<FetchedObject: FetchableObject>: NSObject {
     let wrapped: Wrapped
 
     func associatedValue(with keyPath: PartialKeyPath<FetchedObject>, forObjectID objectID: FetchedObject.ID) throws -> Any? {
-        return try wrapped(keyPath, objectID)
+        try wrapped(keyPath, objectID)
     }
 
     init(wrapped: @escaping Wrapped) {
@@ -1542,7 +1540,7 @@ private extension [NSSortDescriptor] {
     func finalize<FetchedObject: FetchableObject>(
         with controller: FetchedResultsController<FetchedObject>
     ) -> Self {
-        return finalize(sectionNameKeyPath: controller.sectionNameKeyPath) { [weak controller] id in
+        finalize(sectionNameKeyPath: controller.sectionNameKeyPath) { [weak controller] id in
             // Note: OrderedSet.firstIndex(of:) is *not* O(n)
             controller?.fetchedObjectIDs.firstIndex(of: id)
         }

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -82,12 +82,12 @@ public extension FetchedResultsControllerProtocol {
 
         let comparator = sortDescriptors.comparator
         return array.binarySearch {
-            return comparator($0, object) == .orderedAscending
+            comparator($0, object) == .orderedAscending
         }
     }
 
     func object(at indexPath: IndexPath) -> FetchedObject {
-        return sections[indexPath.section].objects[indexPath.item]
+        sections[indexPath.section].objects[indexPath.item]
     }
 
     func indexPath(for object: FetchedObject) -> IndexPath? {

--- a/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
@@ -143,20 +143,20 @@ extension PausableFetchedResultsController: FetchedResultsControllerProtocol {
     }
 
     public var definition: FetchDefinition<FetchedObject> {
-        return controller.definition
+        controller.definition
     }
 
     public var sortDescriptors: [NSSortDescriptor] {
-        return controller.sortDescriptors
+        controller.sortDescriptors
     }
 
     public var sectionNameKeyPath: SectionNameKeyPath? {
-        return controller.sectionNameKeyPath
+        controller.sectionNameKeyPath
     }
 
     public var associatedFetchSize: Int {
         get {
-            return controller.associatedFetchSize
+            controller.associatedFetchSize
         }
         set {
             controller.associatedFetchSize = newValue
@@ -164,15 +164,15 @@ extension PausableFetchedResultsController: FetchedResultsControllerProtocol {
     }
 
     public var hasFetchedObjects: Bool {
-        return hasFetchedObjectsSnapshot ?? controller.hasFetchedObjects
+        hasFetchedObjectsSnapshot ?? controller.hasFetchedObjects
     }
 
     public var fetchedObjects: [FetchedObject] {
-        return fetchedObjectsSnapshot ?? controller.fetchedObjects
+        fetchedObjectsSnapshot ?? controller.fetchedObjects
     }
 
     public var sections: [Section] {
-        return sectionsSnapshot ?? controller.sections
+        sectionsSnapshot ?? controller.sections
     }
 }
 

--- a/FetchRequests/Sources/IndexPath+Convenience.swift
+++ b/FetchRequests/Sources/IndexPath+Convenience.swift
@@ -14,8 +14,8 @@ import UIKit
 import AppKit
 #else
 extension IndexPath {
-    var section: Int { return self[0] }
-    var item: Int { return self[1] }
+    var section: Int { self[0] }
+    var item: Int { self[1] }
 
     init(item: Int, section: Int) {
         self.init(indexes: [section, item])

--- a/FetchRequests/Sources/JSON.swift
+++ b/FetchRequests/Sources/JSON.swift
@@ -94,39 +94,39 @@ extension JSON {
     }
 
     public var string: String? {
-        return object as? String
+        object as? String
     }
 
     public var number: NSNumber? {
-        return object as? NSNumber
+        object as? NSNumber
     }
 
     public var int: Int? {
-        return number?.intValue
+        number?.intValue
     }
 
     public var int64: Int64? {
-        return number?.int64Value
+        number?.int64Value
     }
 
     public var float: Float? {
-        return number?.floatValue
+        number?.floatValue
     }
 
     public var double: Double? {
-        return number?.doubleValue
+        number?.doubleValue
     }
 
     public var null: NSNull? {
-        return object as? NSNull
+        object as? NSNull
     }
 
     public var dictionary: [String: Any]? {
-        return object as? [String: Any]
+        object as? [String: Any]
     }
 
     public var array: [Any]? {
-        return object as? [Any]
+        object as? [Any]
     }
 
     public var bool: Bool? {
@@ -142,7 +142,7 @@ extension JSON {
 extension JSON {
     public subscript(dynamicMember member: String) -> JSON? {
         get {
-            return self[member]
+            self[member]
         }
         set {
             self[member] = newValue
@@ -430,7 +430,7 @@ public enum JSONError: Error {
 
 private extension [String: Any] {
     func encodableDictionary() throws -> [String: JSON] {
-        return try reduce(into: [:]) { memo, kvp in
+        try reduce(into: [:]) { memo, kvp in
             guard let value = JSON(kvp.value) else {
                 throw JSONError.invalidContent
             }
@@ -441,7 +441,7 @@ private extension [String: Any] {
 
 private extension [Any] {
     func encodableArray() throws -> [JSON] {
-        return try map { element in
+        try map { element in
             guard let value = JSON(element) else {
                 throw JSONError.invalidContent
             }
@@ -541,11 +541,11 @@ private let cfBool: CFBoolean = true as CFBoolean
 
 private extension NSNumber {
     var isBool: Bool {
-        return type(of: self) == type(of: nsBool) || type(of: self) == type(of: cfBool)
+        type(of: self) == type(of: nsBool) || type(of: self) == type(of: cfBool)
     }
 
     var isFloatingPoint: Bool {
-        return CFNumberIsFloatType(self as CFNumber)
+        CFNumberIsFloatType(self as CFNumber)
     }
 
     var expectedType: NumberType {
@@ -573,19 +573,19 @@ public protocol JSONConvertible {
 
 extension JSON: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return self
+        self
     }
 }
 
 extension Array: JSONConvertible where Element: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .array(map { $0.jsonRepresentation().object })
+        .array(map { $0.jsonRepresentation().object })
     }
 }
 
 extension Dictionary: JSONConvertible where Key == String, Value: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .dictionary(
+        .dictionary(
             reduce(into: [:]) { memo, kvp in
                 memo[kvp.key] = kvp.value.jsonRepresentation().object
             }
@@ -595,19 +595,19 @@ extension Dictionary: JSONConvertible where Key == String, Value: JSONConvertibl
 
 extension String: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .string(self)
+        .string(self)
     }
 }
 
 extension NSString: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .string(self as String)
+        .string(self as String)
     }
 }
 
 extension NSNull: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .null
+        .null
     }
 }
 
@@ -623,78 +623,78 @@ extension NSNumber: JSONConvertible {
 
 extension Bool: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .bool(self)
+        .bool(self)
     }
 }
 
 extension Int64: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension Int32: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension Int16: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension Int8: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension Int: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension UInt64: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension UInt32: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension UInt16: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension UInt8: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension UInt: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension Double: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }
 
 extension Float: JSONConvertible {
     public func jsonRepresentation() -> JSON {
-        return .number(NSNumber(value: self))
+        .number(NSNumber(value: self))
     }
 }

--- a/FetchRequests/Sources/OrderedSetCompat.swift
+++ b/FetchRequests/Sources/OrderedSetCompat.swift
@@ -267,7 +267,7 @@ extension OrderedSet {
     }
 
     private func index(of element: Element) -> Int? {
-        return indexed[element]
+        indexed[element]
     }
 
     public func firstIndex(of element: Element) -> Int? {

--- a/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
+++ b/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
@@ -14,12 +14,12 @@ public struct SectionedFetchableRequest<FetchedObject: FetchableObject>: Dynamic
     private var base: FetchableResults<FetchedObject>
 
     public var wrappedValue: SectionedFetchableResults<FetchedObject> {
-        return SectionedFetchableResults(contents: _base.fetchController.sections)
+        SectionedFetchableResults(contents: _base.fetchController.sections)
     }
 
     /// Has performFetch() completed?
     public var hasFetchedObjects: Bool {
-        return _base.hasFetchedObjects
+        _base.hasFetchedObjects
     }
 
     public init(
@@ -64,7 +64,7 @@ public struct FetchableRequest<FetchedObject: FetchableObject>: DynamicProperty 
 
     /// Has performFetch() completed?
     public var hasFetchedObjects: Bool {
-        return fetchController.hasFetchedObjects
+        fetchController.hasFetchedObjects
     }
 
     public init(
@@ -149,28 +149,28 @@ public struct SectionedFetchableResults<FetchedObject: FetchableObject> {
 
 extension FetchableResults: RandomAccessCollection {
     public var startIndex: Int {
-        return contents.startIndex
+        contents.startIndex
     }
 
     public var endIndex: Int {
-        return contents.endIndex
+        contents.endIndex
     }
 
     public subscript(position: Int) -> FetchedObject {
-        return contents[position]
+        contents[position]
     }
 }
 
 extension SectionedFetchableResults: RandomAccessCollection {
     public var startIndex: Int {
-        return contents.startIndex
+        contents.startIndex
     }
 
     public var endIndex: Int {
-        return contents.endIndex
+        contents.endIndex
     }
 
     public subscript(position: Int) -> FetchedResultsSection<FetchedObject> {
-        return contents[position]
+        contents[position]
     }
 }

--- a/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/CollapsibleSectionsFetchedResultsControllerTestCase.swift
@@ -9,17 +9,20 @@
 import XCTest
 @testable import FetchRequests
 
-// swiftlint:disable force_try implicitly_unwrapped_optional type_name
-
 @MainActor
+// swiftlint:disable:next type_name
 class CollapsibleSectionsFetchedResultsControllerTestCase: XCTestCase {
-    typealias FetchController = CollapsibleSectionsFetchedResultsController<TestObject>
+    private typealias FetchController = CollapsibleSectionsFetchedResultsController<TestObject>
+
+    // swiftlint:disable implicitly_unwrapped_optional
 
     private var controller: CollapsibleSectionsFetchedResultsController<TestObject>!
 
     private var fetchCompletion: (([TestObject]) -> Void)!
 
     private var associationRequest: TestObject.AssociationRequest!
+
+    // swiftlint:enable implicitly_unwrapped_optional
 
     private var inclusionCheck: ((TestObject.RawData) -> Bool)?
 
@@ -40,7 +43,7 @@ class CollapsibleSectionsFetchedResultsControllerTestCase: XCTestCase {
         }
 
         let inclusionCheck: FetchDefinition<TestObject>.CreationInclusionCheck = { [unowned self] rawData in
-            return self.inclusionCheck?(rawData) ?? true
+            self.inclusionCheck?(rawData) ?? true
         }
 
         return FetchDefinition<TestObject>(
@@ -89,46 +92,46 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase: CollapsibleSectio
 
 // MARK: - Collapse/Expand Tests
 extension CollapsibleSectionsFetchedResultsControllerTestCase {
-    func testInitialSectionCollapse() {
+    func testInitialSectionCollapse() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "0"
+                section.name == "0"
             }
         )
 
         let objects = createTestObjects(count: 15, inSectionsOfLength: 5)
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertTrue(controller.sections[0].isCollapsed)
     }
 
-    func testHidingSection() {
-        testInitialSectionCollapse()
+    func testHidingSection() throws {
+        try testInitialSectionCollapse()
         let sectionToCollapse = controller.sections[1]
         controller.collapse(section: sectionToCollapse)
         let updatedSection = controller.sections[1]
         XCTAssertTrue(updatedSection.isCollapsed)
     }
 
-    func testExpandingSection() {
-        testInitialSectionCollapse()
+    func testExpandingSection() throws {
+        try testInitialSectionCollapse()
         let sectionToExpand = controller.sections[0]
         controller.expand(section: sectionToExpand)
         let updatedSection = controller.sections[0]
         XCTAssertFalse(updatedSection.isCollapsed)
     }
 
-    func testInitialSectionConfigCheck() {
+    func testInitialSectionConfigCheck() throws {
         let maxNumberOfItems = 4
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "0"
+                section.name == "0"
             },
             sectionConfigCheck: { section in
                 if section.name == "0" {
@@ -140,7 +143,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         )
 
         let originalObjects = createTestObjects(count: 20, inSectionsOfLength: 10)
-        try! performFetch(originalObjects)
+        try performFetch(originalObjects)
 
         XCTAssert(controller.sections[0].allObjects.count == 10)
         XCTAssertEqual(controller.sections[0].displayableObjects.count, maxNumberOfItems)
@@ -152,14 +155,14 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[0].displayableObjects.count, 6)
     }
 
-    func testSectionUpdatesWhenCollapsed() {
+    func testSectionUpdatesWhenCollapsed() throws {
         let maxNumberOfItems = 4
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "0"
+                section.name == "0"
             },
             sectionConfigCheck: { section in
                 if section.name == "0" {
@@ -172,7 +175,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         controller.setDelegate(self)
 
         let originalObjects = createTestObjects(count: 6, inSectionsOfLength: 3)
-        try! performFetch(originalObjects)
+        try performFetch(originalObjects)
 
         XCTAssertTrue(controller.sections[0].isCollapsed)
         XCTAssertEqual(controller.sections[0].displayableObjects, controller.sections[0].allObjects)
@@ -192,19 +195,19 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(sectionChangeEvents[0].change, FetchedResultsChange.update(location: 0))
     }
 
-    func testObjectUpdatesAfterExpanding() {
+    func testObjectUpdatesAfterExpanding() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "0"
+                section.name == "0"
             }
         )
         controller.setDelegate(self)
 
         let originalObjects = createTestObjects(count: 6, inSectionsOfLength: 3)
-        try! performFetch(originalObjects)
+        try performFetch(originalObjects)
 
         controller.update(section: controller.sections[0], maximumNumberOfItemsToDisplay: 4)
         XCTAssertTrue(controller.sections[0].isCollapsed)
@@ -225,8 +228,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(sectionChangeEvents.count, 0)
     }
 
-    func testNumberOfItemsToShowWhenExceedingMax() {
-        testInitialSectionCollapse()
+    func testNumberOfItemsToShowWhenExceedingMax() throws {
+        try testInitialSectionCollapse()
         controller.expand(section: controller.sections[0])
         controller.update(section: controller.sections[0], maximumNumberOfItemsToDisplay: 4, whenExceedingMax: 3)
         XCTAssertEqual(controller.sections[0].displayableObjects.count, controller.sections[0].allObjects.count)
@@ -235,19 +238,19 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[0].displayableObjects.count, 3)
     }
 
-    func testIndexPath() {
+    func testIndexPath() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "0"
+                section.name == "0"
             }
         )
         controller.setDelegate(self)
 
         let originalObjects = createTestObjects(count: 6, inSectionsOfLength: 6)
-        try! performFetch(originalObjects)
+        try performFetch(originalObjects)
 
         let maxNumberOfItems = 4
         controller.update(section: controller.sections[0], maximumNumberOfItemsToDisplay: maxNumberOfItems)
@@ -259,21 +262,21 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
     }
 
     // Test hidden item is not found
-    func testIndexPathNilFromCollapse() {
-        testIndexPath()
+    func testIndexPathNilFromCollapse() throws {
+        try testIndexPath()
 
         let objectHiddenFromCollapse = controller.sections[0].allObjects.last!
         let indexPath = controller.indexPath(for: objectHiddenFromCollapse)
         XCTAssertNil(indexPath)
     }
 
-    func testItemMovingSections() {
+    func testItemMovingSections() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "0"
+                section.name == "0"
             },
             sectionConfigCheck: { section in
                 if section.name == "0" {
@@ -286,7 +289,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         controller.setDelegate(self)
 
         let originalObjects = createTestObjects(count: 10, inSectionsOfLength: 5)
-        try! performFetch(originalObjects)
+        try performFetch(originalObjects)
 
         changeEvents.removeAll()
         sectionChangeEvents.removeAll()
@@ -325,13 +328,13 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(sectionChangeEvents.count, 1)
     }
 
-    func testInsertingItemsTriggersCollapse() {
+    func testInsertingItemsTriggersCollapse() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "0"
+                section.name == "0"
             },
             sectionConfigCheck: { section in
                 guard section.name == "0" else {
@@ -348,7 +351,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         controller.setDelegate(self)
 
         let originalObjects = createTestObjects(count: 6, inSectionsOfLength: 3)
-        try! performFetch(originalObjects)
+        try performFetch(originalObjects)
 
         XCTAssertEqual(controller.sections[0].numberOfDisplayableObjects, 3)
         XCTAssertTrue(controller.sections[0].isCollapsed)
@@ -365,7 +368,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         changeEvents.removeAll()
         sectionChangeEvents.removeAll()
 
-        try! performFetch(originalObjects + newObjects)
+        try performFetch(originalObjects + newObjects)
 
         XCTAssertEqual(controller.sections[0].numberOfDisplayableObjects, 4)
         XCTAssertTrue(controller.sections[0].isCollapsed)
@@ -377,8 +380,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(sectionChangeEvents[0].change, FetchedResultsChange.update(location: 0))
     }
 
-    func testDeletingItemsTriggersExpansion() {
-        testInsertingItemsTriggersCollapse()
+    func testDeletingItemsTriggersExpansion() throws {
+        try testInsertingItemsTriggersCollapse()
 
         // Delete Entity
 
@@ -423,25 +426,25 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 // MARK: - FetchedResultsControllerTestCase Tests
 
 extension CollapsibleSectionsFetchedResultsControllerTestCase {
-    func testBasicFetch() {
+    func testBasicFetch() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
             debounceInsertsAndReloads: false,
             initialSectionCollapseCheck: { section in
-                return section.name == "1"
+                section.name == "1"
             }
         )
 
         let objects = createTestObjects(count: 15, inSectionsOfLength: 5)
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertEqual(controller.sections.count, 3)
         XCTAssertEqual(controller.sections[0].allObjects.count, 5)
     }
 
-    func testResort() {
+    func testResort() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -449,7 +452,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
 
@@ -457,8 +460,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[0].allFetchedIDs, objectIDs.reversed())
     }
 
-    func testAccessByIndexPath() {
-        testBasicFetch()
+    func testAccessByIndexPath() throws {
+        try testBasicFetch()
 
         let firstIndexPath = IndexPath(item: 0, section: 0)
         let lastIndexPath = IndexPath(item: 2, section: 0)
@@ -476,7 +479,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(lastIndexPath, fetchedLastIndexPath)
     }
 
-    func testFetchAvoidsReplacingInstances() {
+    func testFetchAvoidsReplacingInstances() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -485,7 +488,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         let objects = createTestObjects(count: 3, inSectionsOfLength: Int.max)
         var currentTag = (objects.last?.tag ?? 0) + 1
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Replace our instances
 
@@ -498,7 +501,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(secondaryObjects)
+        try performFetch(secondaryObjects)
 
         XCTAssertEqual(controller.fetchedIDs.count, secondaryObjectIDs.count)
         XCTAssertEqual(controller.sections.count, 1)
@@ -508,7 +511,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[0].allTags, [3, 0, 2, 6, 7])
     }
 
-    func testBasicFetchWithSortDescriptors() {
+    func testBasicFetchWithSortDescriptors() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sortDescriptors: [
@@ -521,9 +524,9 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         // Handle all kinds of order variations
 
-        try! performFetch(["c", "b", "a"])
-        try! performFetch(["a", "b", "c"])
-        try! performFetch(["b", "a", "c"])
+        try performFetch(["c", "b", "a"])
+        try performFetch(["a", "b", "c"])
+        try performFetch(["b", "a", "c"])
 
         XCTAssertEqual(controller.fetchedIDs, objectIDs)
         XCTAssertEqual(controller.sections.count, 1)
@@ -533,7 +536,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
 // MARK: - Sections
 extension CollapsibleSectionsFetchedResultsControllerTestCase {
-    func testFetchingIntoSections() {
+    func testFetchingIntoSections() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
@@ -544,7 +547,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         var objects = zip(objectIDs, objectIDs.reversed()).compactMap { TestObject(id: $0, sectionName: $1) }
         objects.append(TestObject(id: "d", sectionName: "b"))
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Make sure our sections meet our expectations
 
@@ -555,8 +558,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].allObjects, [objects[0]])
     }
 
-    func testFetchingIntoSectionsAndAccessingByIndexPath() {
-        testFetchingIntoSections()
+    func testFetchingIntoSectionsAndAccessingByIndexPath() throws {
+        try testFetchingIntoSections()
 
         let firstIndexPath = IndexPath(item: 0, section: 0)
         let middleIndexPath = IndexPath(item: 1, section: 1)
@@ -579,7 +582,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(lastIndexPath, fetchedLastIndexPath)
     }
 
-    func testFetchingIntoSectionsAvoidsReplacingInstances() {
+    func testFetchingIntoSectionsAvoidsReplacingInstances() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
@@ -598,7 +601,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertEqual(controller.fetchedIDs, ["a", "b", "d", "c"])
 
@@ -614,7 +617,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(secondaryObjects)
+        try performFetch(secondaryObjects)
 
         XCTAssertEqual(controller.fetchedIDs, ["z", "a", "c", "b", "d"])
         XCTAssertEqual(controller.sections.count, 2)
@@ -626,7 +629,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[1].allTags, [6, 1, 2])
     }
 
-    func testFetchingIntoSectionsWithSortDescriptors() {
+    func testFetchingIntoSectionsWithSortDescriptors() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sortDescriptors: [
@@ -644,7 +647,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Verify sorts work inside of sections
 
@@ -658,14 +661,14 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
 // MARK: - Associated Values
 extension CollapsibleSectionsFetchedResultsControllerTestCase {
-    func testFetchingAssociatedObjects() {
+    func testFetchingAssociatedObjects() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
             debounceInsertsAndReloads: false
         )
         controller.associatedFetchSize = 3
 
-        try! performFetch(["a", "b", "c", "d"])
+        try performFetch(["a", "b", "c", "d"])
 
         // Fault on C
 
@@ -709,13 +712,13 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
     }
 
 #if canImport(UIKit) && !os(watchOS)
-    func testAssociatedValuesAreDumpedOnMemoryPressure() {
+    func testAssociatedValuesAreDumpedOnMemoryPressure() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
             debounceInsertsAndReloads: false
         )
 
-        try! performFetch(["a", "b", "c", "d"])
+        try performFetch(["a", "b", "c", "d"])
 
         // Fault on C
 
@@ -746,13 +749,13 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
     }
 #endif
 
-    func testAssociatedObjectsInvalidatedFromKVO() {
+    func testAssociatedObjectsInvalidatedFromKVO() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
             debounceInsertsAndReloads: false
         )
 
-        try! performFetch(["a", "b", "c", "d"])
+        try performFetch(["a", "b", "c", "d"])
 
         // Fault on C
 
@@ -783,7 +786,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(tagString2, "2")
     }
 
-    func testMissingAssociatedObjectsInvalidatedFromNotifications() {
+    func testMissingAssociatedObjectsInvalidatedFromNotifications() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tagID]),
             debounceInsertsAndReloads: false
@@ -801,7 +804,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on C
 
@@ -840,7 +843,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 }
 
 extension CollapsibleSectionsFetchedResultsControllerTestCase {
-    private func setupControllerForKVO(_ file: StaticString = #file, line: UInt = #line) {
+    private func setupControllerForKVO(_ file: StaticString = #file, line: UInt = #line) throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             sortDescriptors: [
@@ -862,7 +865,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"], file: file, line: line)
         XCTAssertEqual(controller.sections.count, 3, file: file, line: line)
@@ -871,8 +874,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].allFetchedIDs, ["c", "d"], file: file, line: line)
     }
 
-    func testSectionChangeFromKVO() {
-        setupControllerForKVO()
+    func testSectionChangeFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify C ~> Move Section w/o Adding or Deleting
 
@@ -888,8 +891,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].allFetchedIDs, ["d"])
     }
 
-    func testSectionCreationFromKVO() {
-        setupControllerForKVO()
+    func testSectionCreationFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify Z ~> Move Section Adding Section
 
@@ -906,8 +909,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[3].allFetchedIDs, ["z"])
     }
 
-    func testSectionDeletionFromKVO() {
-        setupControllerForKVO()
+    func testSectionDeletionFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify B ~> Move Section Deleting Section
 
@@ -922,8 +925,8 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[1].allFetchedIDs, ["c", "b", "d"])
     }
 
-    func testOrderChangeFromKVO() {
-        setupControllerForKVO()
+    func testOrderChangeFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify Z ~> Reorder contents in section
 
@@ -936,11 +939,11 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].allFetchedIDs, ["c", "d"])
     }
 
-    func testDeleteFromKVO() {
+    func testDeleteFromKVO() throws {
         controller = FetchController(definition: createFetchDefinition(), debounceInsertsAndReloads: false)
         controller.setDelegate(self)
 
-        try! performFetch(["a", "b", "c"])
+        try performFetch(["a", "b", "c"])
 
         changeEvents.removeAll()
 
@@ -957,7 +960,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(changeEvents[0].object.id, "a")
     }
 
-    func testAssociatedObjectDeleteFromKVO() {
+    func testAssociatedObjectDeleteFromKVO() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tagID]),
             debounceInsertsAndReloads: false
@@ -975,7 +978,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -1005,7 +1008,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testAssociatedObjectArrayDeleteFromKVO() {
+    func testAssociatedObjectArrayDeleteFromKVO() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tagIDs]),
             debounceInsertsAndReloads: false
@@ -1023,7 +1026,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -1053,7 +1056,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testExpectNoReloadFromKVO() {
+    func testExpectNoReloadFromKVO() throws {
         // We need a custom controller so that sort descriptors is "empty"
         controller = FetchController(
             definition: createFetchDefinition(),
@@ -1064,7 +1067,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         let objectSectionPairs = [("z", "a"), ("a", "a"), ("c", "c"), ("b", "b"), ("d", "c")]
         let objects = objectSectionPairs.compactMap { TestObject(id: $0, sectionName: $1) }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"])
         XCTAssertEqual(controller.sections.count, 3)
@@ -1087,11 +1090,11 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].allFetchedIDs, ["c", "d"])
     }
 
-    func testExpectReloadFromKVO() {
+    func testExpectReloadFromKVO() throws {
         controller = FetchController(definition: createFetchDefinition(), debounceInsertsAndReloads: false)
         controller.setDelegate(self)
 
-        try! performFetch(["a", "b", "c"])
+        try performFetch(["a", "b", "c"])
 
         changeEvents.removeAll()
 
@@ -1104,7 +1107,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(changeEvents[0].object.id, "a")
     }
 
-    func testExpectReloadFromAssociatedObjectKVO() {
+    func testExpectReloadFromAssociatedObjectKVO() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tagID]),
             debounceInsertsAndReloads: false
@@ -1122,7 +1125,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -1152,7 +1155,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testExpectReloadFromAssociatedObjectArrayKVO() {
+    func testExpectReloadFromAssociatedObjectArrayKVO() throws {
         controller = FetchController(
             definition: createFetchDefinition(associations: [\TestObject.tagIDs]),
             debounceInsertsAndReloads: false
@@ -1170,7 +1173,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -1200,7 +1203,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testExpectInsertFromBroadcastNotification() {
+    func testExpectInsertFromBroadcastNotification() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -1209,7 +1212,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         let initialObjects = ["a", "b", "c"].compactMap { TestObject(id: $0) }
 
-        try! performFetch(initialObjects)
+        try performFetch(initialObjects)
 
         fetchCompletion = nil
         changeEvents.removeAll()
@@ -1237,7 +1240,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssert(changeEvents.isEmpty)
     }
 
-    func testExpectNoInsertFromBroadcastNotification() {
+    func testExpectNoInsertFromBroadcastNotification() throws {
         controller = FetchController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -1246,7 +1249,7 @@ extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
         let initialObjects = ["a", "b", "c"].compactMap { TestObject(id: $0) }
 
-        try! performFetch(initialObjects)
+        try performFetch(initialObjects)
 
         fetchCompletion = nil
         changeEvents.removeAll()
@@ -1291,6 +1294,7 @@ private extension CollapsibleSectionsFetchedResultsControllerTestCase {
         XCTAssertEqual(sortedObjects, controller.fetchedObjects, file: file, line: line)
     }
 
+    // swiftlint:disable:next implicitly_unwrapped_optional
     func getObjectAtIndex(_ index: Int, withObjectID objectID: String, file: StaticString = #file, line: UInt = #line) -> TestObject! {
         let object = controller.fetchedObjects[index]
 
@@ -1302,7 +1306,7 @@ private extension CollapsibleSectionsFetchedResultsControllerTestCase {
     func createTestObjects(count: Int, inSectionsOfLength maxSectionLength: Int, startingWithID startID: Int = 0) -> [TestObject] {
         let idRange = startID ..< (startID + count)
         return idRange.compactMap { index in
-            return TestObject(
+            TestObject(
                 id: "\(index)",
                 tag: index,
                 sectionName: "\(index / maxSectionLength)"
@@ -1313,24 +1317,24 @@ private extension CollapsibleSectionsFetchedResultsControllerTestCase {
 
 extension CollapsibleSectionsFetchedResultsController where FetchedObject: TestObject {
     var fetchedIDs: [String] {
-        return fetchedObjects.map(\.id)
+        fetchedObjects.map(\.id)
     }
 
     var tags: [Int] {
-        return fetchedObjects.map(\.tag)
+        fetchedObjects.map(\.tag)
     }
 }
 
 extension CollapsibleResultsSection where FetchedObject: TestObject {
     var allFetchedIDs: [String] {
-        return allObjects.map(\.id)
+        allObjects.map(\.id)
     }
 
     var displayableFetchedIDs: [String] {
-        return displayableObjects.map(\.id)
+        displayableObjects.map(\.id)
     }
 
     var allTags: [Int] {
-        return allObjects.map(\.tag)
+        allObjects.map(\.tag)
     }
 }

--- a/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/FetchedResultsControllerTestCase.swift
@@ -9,14 +9,17 @@
 import XCTest
 @testable import FetchRequests
 
-// swiftlint:disable force_try implicitly_unwrapped_optional
 @MainActor
 class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTestHarness {
+    // swiftlint:disable implicitly_unwrapped_optional test_case_accessibility
+
     private(set) var controller: FetchedResultsController<TestObject>!
 
     private(set) var fetchCompletion: (([TestObject]) -> Void)!
 
     private var associationRequest: TestObject.AssociationRequest!
+
+    // swiftlint:enable implicitly_unwrapped_optional test_case_accessibility
 
     private var inclusionCheck: ((TestObject.RawData) -> Bool)?
 
@@ -36,7 +39,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
         }
 
         let inclusionCheck: FetchDefinition<TestObject>.CreationInclusionCheck = { [unowned self] rawData in
-            return self.inclusionCheck?(rawData) ?? true
+            self.inclusionCheck?(rawData) ?? true
         }
 
         return FetchDefinition<TestObject>(
@@ -61,7 +64,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
         changeEvents = []
     }
 
-    func testBasicFetch() {
+    func testBasicFetch() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -69,13 +72,13 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         XCTAssertEqual(controller.sections.count, 1)
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs)
     }
 
-    func testResort() {
+    func testResort() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -83,7 +86,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
 
@@ -91,8 +94,8 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs.reversed())
     }
 
-    func testReset() {
-        testBasicFetch()
+    func testReset() throws {
+        try testBasicFetch()
         controller.setDelegate(self)
 
         changeEvents.removeAll()
@@ -108,7 +111,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
         XCTAssertEqual(controller.fetchedObjects, [])
     }
 
-    func testClearDelegate() {
+    func testClearDelegate() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -117,7 +120,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         XCTAssertEqual(changeEvents.count, 3)
         XCTAssertEqual(controller.fetchedObjects.count, 3)
@@ -125,14 +128,14 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
         changeEvents.removeAll()
         controller.clearDelegate()
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         XCTAssertEqual(changeEvents.count, 0)
         XCTAssertEqual(controller.fetchedObjects.count, 3)
     }
 
-    func testAccessByIndexPath() {
-        testBasicFetch()
+    func testAccessByIndexPath() throws {
+        try testBasicFetch()
 
         let firstIndexPath = IndexPath(item: 0, section: 0)
         let lastIndexPath = IndexPath(item: 2, section: 0)
@@ -150,7 +153,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
         XCTAssertEqual(lastIndexPath, fetchedLastIndexPath)
     }
 
-    func testFetchAvoidsReplacingInstances() {
+    func testFetchAvoidsReplacingInstances() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -167,7 +170,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Replace our instances
 
@@ -180,7 +183,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
             return object
         }
 
-        try! performFetch(secondaryObjects)
+        try performFetch(secondaryObjects)
 
         XCTAssertEqual(controller.fetchedIDs.count, secondaryObjectIDs.count)
         XCTAssertEqual(controller.sections.count, 1)
@@ -190,7 +193,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
         XCTAssertEqual(controller.sections[0].tags, [3, 0, 2, 6, 7])
     }
 
-    func testBasicFetchWithSortDescriptors() {
+    func testBasicFetchWithSortDescriptors() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             sortDescriptors: [
@@ -203,9 +206,9 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
 
         // Handle all kinds of order variations
 
-        try! performFetch(["c", "b", "a"])
-        try! performFetch(["a", "b", "c"])
-        try! performFetch(["b", "a", "c"])
+        try performFetch(["c", "b", "a"])
+        try performFetch(["a", "b", "c"])
+        try performFetch(["b", "a", "c"])
 
         XCTAssertEqual(controller.fetchedIDs, objectIDs)
         XCTAssertEqual(controller.sections.count, 1)
@@ -216,7 +219,7 @@ class FetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTest
 // MARK: - Sections
 
 extension FetchedResultsControllerTestCase {
-    func testFetchingIntoSections() {
+    func testFetchingIntoSections() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
@@ -227,7 +230,7 @@ extension FetchedResultsControllerTestCase {
         var objects = zip(objectIDs, objectIDs.reversed()).compactMap { TestObject(id: $0, sectionName: $1) }
         objects.append(TestObject(id: "d", sectionName: "b"))
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Make sure our sections meet our expectations
 
@@ -238,8 +241,8 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].objects, [objects[0]])
     }
 
-    func testFetchingIntoSectionsAndAccessingByIndexPath() {
-        testFetchingIntoSections()
+    func testFetchingIntoSectionsAndAccessingByIndexPath() throws {
+        try testFetchingIntoSections()
 
         let firstIndexPath = IndexPath(item: 0, section: 0)
         let middleIndexPath = IndexPath(item: 1, section: 1)
@@ -262,7 +265,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(lastIndexPath, fetchedLastIndexPath)
     }
 
-    func testFetchingIntoSectionsAvoidsReplacingInstances() {
+    func testFetchingIntoSectionsAvoidsReplacingInstances() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
@@ -281,7 +284,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertEqual(controller.fetchedIDs, ["a", "b", "d", "c"])
 
@@ -297,7 +300,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(secondaryObjects)
+        try performFetch(secondaryObjects)
 
         XCTAssertEqual(controller.fetchedIDs, ["z", "a", "c", "b", "d"])
         XCTAssertEqual(controller.sections.count, 2)
@@ -309,7 +312,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[1].tags, [6, 1, 2])
     }
 
-    func testFetchingIntoSectionsWithSortDescriptors() {
+    func testFetchingIntoSectionsWithSortDescriptors() throws {
         controller = FetchedResultsController<TestObject>(
             definition: createFetchDefinition(),
             sortDescriptors: [
@@ -327,7 +330,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Verify sorts work inside of sections
 
@@ -342,14 +345,14 @@ extension FetchedResultsControllerTestCase {
 // MARK: - Associated Values
 
 extension FetchedResultsControllerTestCase {
-    func testFetchingAssociatedObjects() {
+    func testFetchingAssociatedObjects() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
             debounceInsertsAndReloads: false
         )
         controller.associatedFetchSize = 3
 
-        try! performFetch(["a", "b", "c", "d"])
+        try performFetch(["a", "b", "c", "d"])
 
         // Fault on C
 
@@ -392,13 +395,13 @@ extension FetchedResultsControllerTestCase {
     }
 
 #if canImport(UIKit) && !os(watchOS)
-    func testAssociatedValuesAreDumpedOnMemoryPressure() {
+    func testAssociatedValuesAreDumpedOnMemoryPressure() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
             debounceInsertsAndReloads: false
         )
 
-        try! performFetch(["a", "b", "c", "d"])
+        try performFetch(["a", "b", "c", "d"])
 
         // Fault on C
 
@@ -429,13 +432,13 @@ extension FetchedResultsControllerTestCase {
     }
 #endif
 
-    func testAssociatedObjectsInvalidatedFromKVO() {
+    func testAssociatedObjectsInvalidatedFromKVO() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tag]),
             debounceInsertsAndReloads: false
         )
 
-        try! performFetch(["a", "b", "c", "d"])
+        try performFetch(["a", "b", "c", "d"])
 
         // Fault on C
 
@@ -466,7 +469,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(tagString2, "2")
     }
 
-    func testMissingAssociatedObjectsInvalidatedFromNotifications() {
+    func testMissingAssociatedObjectsInvalidatedFromNotifications() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tagID]),
             debounceInsertsAndReloads: false
@@ -484,7 +487,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on C
 
@@ -525,7 +528,7 @@ extension FetchedResultsControllerTestCase {
 // MARK: - Observed Events
 
 extension FetchedResultsControllerTestCase {
-    private func setupControllerForKVO(_ file: StaticString = #file, line: UInt = #line) {
+    private func setupControllerForKVO(_ file: StaticString = #file, line: UInt = #line) throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             sortDescriptors: [
@@ -547,7 +550,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"], file: file, line: line)
         XCTAssertEqual(controller.sections.count, 3, file: file, line: line)
@@ -556,8 +559,8 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].fetchedIDs, ["c", "d"], file: file, line: line)
     }
 
-    func testSectionChangeFromKVO() {
-        setupControllerForKVO()
+    func testSectionChangeFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify C ~> Move Section w/o Adding or Deleting
 
@@ -573,8 +576,8 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].fetchedIDs, ["d"])
     }
 
-    func testSectionCreationFromKVO() {
-        setupControllerForKVO()
+    func testSectionCreationFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify Z ~> Move Section Adding Section
 
@@ -591,8 +594,8 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[3].fetchedIDs, ["z"])
     }
 
-    func testSectionDeletionFromKVO() {
-        setupControllerForKVO()
+    func testSectionDeletionFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify B ~> Move Section Deleting Section
 
@@ -607,8 +610,8 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[1].fetchedIDs, ["c", "b", "d"])
     }
 
-    func testOrderChangeFromKVO() {
-        setupControllerForKVO()
+    func testOrderChangeFromKVO() throws {
+        try setupControllerForKVO()
 
         // Modify Z ~> Reorder contents in section
 
@@ -621,11 +624,11 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].fetchedIDs, ["c", "d"])
     }
 
-    func testDeleteFromKVO() {
+    func testDeleteFromKVO() throws {
         controller = FetchedResultsController(definition: createFetchDefinition(), debounceInsertsAndReloads: false)
         controller.setDelegate(self)
 
-        try! performFetch(["a", "b", "c"])
+        try performFetch(["a", "b", "c"])
 
         changeEvents.removeAll()
 
@@ -642,7 +645,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(changeEvents[0].object.id, "a")
     }
 
-    func testAssociatedObjectDeleteFromKVO() {
+    func testAssociatedObjectDeleteFromKVO() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tagID]),
             debounceInsertsAndReloads: false
@@ -660,7 +663,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -690,7 +693,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testAssociatedObjectArrayDeleteFromKVO() {
+    func testAssociatedObjectArrayDeleteFromKVO() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tagIDs]),
             debounceInsertsAndReloads: false
@@ -708,7 +711,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -738,7 +741,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testExpectNoReloadFromKVO() {
+    func testExpectNoReloadFromKVO() throws {
         // We need a custom controller so that sort descriptors is "empty"
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
@@ -749,7 +752,7 @@ extension FetchedResultsControllerTestCase {
         let objectSectionPairs = [("z", "a"), ("a", "a"), ("c", "c"), ("b", "b"), ("d", "c")]
         let objects = objectSectionPairs.compactMap { TestObject(id: $0, sectionName: $1) }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         XCTAssertEqual(controller.fetchedIDs, ["z", "a", "b", "c", "d"])
         XCTAssertEqual(controller.sections.count, 3)
@@ -772,11 +775,11 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(controller.sections[2].fetchedIDs, ["c", "d"])
     }
 
-    func testExpectReloadFromKVO() {
+    func testExpectReloadFromKVO() throws {
         controller = FetchedResultsController(definition: createFetchDefinition(), debounceInsertsAndReloads: false)
         controller.setDelegate(self)
 
-        try! performFetch(["a", "b", "c"])
+        try performFetch(["a", "b", "c"])
 
         changeEvents.removeAll()
 
@@ -789,7 +792,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertEqual(changeEvents[0].object.id, "a")
     }
 
-    func testExpectReloadFromAssociatedObjectKVO() {
+    func testExpectReloadFromAssociatedObjectKVO() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tagID]),
             debounceInsertsAndReloads: false
@@ -807,7 +810,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -837,7 +840,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testExpectReloadFromAssociatedObjectArrayKVO() {
+    func testExpectReloadFromAssociatedObjectArrayKVO() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(associations: [\TestObject.tagIDs]),
             debounceInsertsAndReloads: false
@@ -855,7 +858,7 @@ extension FetchedResultsControllerTestCase {
             return object
         }
 
-        try! performFetch(objects)
+        try performFetch(objects)
 
         // Fault on A
 
@@ -885,7 +888,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssertNil(associationRequest)
     }
 
-    func testExpectInsertFromBroadcastNotification() {
+    func testExpectInsertFromBroadcastNotification() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -894,7 +897,7 @@ extension FetchedResultsControllerTestCase {
 
         let initialObjects = ["a", "b", "c"].compactMap { TestObject(id: $0) }
 
-        try! performFetch(initialObjects)
+        try performFetch(initialObjects)
 
         fetchCompletion = nil
         changeEvents.removeAll()
@@ -922,7 +925,7 @@ extension FetchedResultsControllerTestCase {
         XCTAssert(changeEvents.isEmpty)
     }
 
-    func testExpectNoInsertFromBroadcastNotification() {
+    func testExpectNoInsertFromBroadcastNotification() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -931,7 +934,7 @@ extension FetchedResultsControllerTestCase {
 
         let initialObjects = ["a", "b", "c"].compactMap { TestObject(id: $0) }
 
-        try! performFetch(initialObjects)
+        try performFetch(initialObjects)
 
         fetchCompletion = nil
         changeEvents.removeAll()
@@ -959,14 +962,14 @@ extension FetchedResultsControllerTestCase {
         XCTAssert(changeEvents.isEmpty)
     }
 
-    func testExpectReloadFromDatabaseReset() {
+    func testExpectReloadFromDatabaseReset() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
         )
         controller.setDelegate(self)
 
-        try! performFetch(["a", "b", "c"])
+        try performFetch(["a", "b", "c"])
 
         XCTAssertEqual(changeEvents.count, 3)
 
@@ -988,7 +991,7 @@ extension FetchedResultsControllerTestCase {
 // MARK: - IndexPath Math
 
 extension FetchedResultsControllerTestCase {
-    private func setupController() {
+    private func setupController() throws {
         controller = FetchedResultsController(
             definition: createFetchDefinition(),
             sectionNameKeyPath: \.sectionName,
@@ -999,72 +1002,72 @@ extension FetchedResultsControllerTestCase {
         var objects = objectIDs.map { TestObject(id: $0, sectionName: "a") }
         objects.append(TestObject(id: "d", sectionName: "b"))
 
-        try! performFetch(objects)
+        try performFetch(objects)
     }
 
-    func testIndexPathNilForMissingObject() {
-        setupController()
+    func testIndexPathNilForMissingObject() throws {
+        try setupController()
 
         let object = TestObject(id: "e")
         XCTAssertNil(controller.indexPath(for: object))
     }
 
-    func testIndexPathAvailableForObject() {
-        setupController()
+    func testIndexPathAvailableForObject() throws {
+        try setupController()
 
         let object = TestObject(id: "b")
         XCTAssertEqual(controller.indexPath(for: object), IndexPath(item: 1, section: 0))
     }
 
-    func testIndexPathNilForMissingObjectMatching() {
-        setupController()
+    func testIndexPathNilForMissingObjectMatching() throws {
+        try setupController()
 
         let indexPath = controller.indexPath(forObjectMatching: { $0.id == "e" })
         XCTAssertNil(indexPath)
     }
 
-    func testIndexPathAvailableForObjectMatching() {
-        setupController()
+    func testIndexPathAvailableForObjectMatching() throws {
+        try setupController()
 
         let indexPath = controller.indexPath(forObjectMatching: { $0.id == "b" })
         XCTAssertEqual(indexPath, IndexPath(item: 1, section: 0))
     }
 
-    func testIndexPathBeforeFirstSection() {
-        setupController()
+    func testIndexPathBeforeFirstSection() throws {
+        try setupController()
 
         XCTAssertNil(controller.getIndexPath(before: IndexPath(item: 0, section: 0)))
     }
 
-    func testIndexPathBeforeRegularSection() {
-        setupController()
+    func testIndexPathBeforeRegularSection() throws {
+        try setupController()
 
         let indexPath = controller.getIndexPath(before: IndexPath(item: 0, section: 1))
         XCTAssertEqual(indexPath, IndexPath(item: 2, section: 0))
     }
 
-    func testIndexPathBeforeItem() {
-        setupController()
+    func testIndexPathBeforeItem() throws {
+        try setupController()
 
         let indexPath = controller.getIndexPath(before: IndexPath(item: 1, section: 0))
         XCTAssertEqual(indexPath, IndexPath(item: 0, section: 0))
     }
 
-    func testIndexPathAfterLastSection() {
-        setupController()
+    func testIndexPathAfterLastSection() throws {
+        try setupController()
 
         XCTAssertNil(controller.getIndexPath(after: IndexPath(item: 0, section: 1)))
     }
 
-    func testIndexPathAfterRegularSection() {
-        setupController()
+    func testIndexPathAfterRegularSection() throws {
+        try setupController()
 
         let indexPath = controller.getIndexPath(after: IndexPath(item: 2, section: 0))
         XCTAssertEqual(indexPath, IndexPath(item: 0, section: 1))
     }
 
-    func testIndexPathAfterItem() {
-        setupController()
+    func testIndexPathAfterItem() throws {
+        try setupController()
 
         let indexPath = controller.getIndexPath(after: IndexPath(item: 1, section: 0))
         XCTAssertEqual(indexPath, IndexPath(item: 2, section: 0))

--- a/FetchRequests/Tests/Controllers/FetchedResultsControllerTestHarness.swift
+++ b/FetchRequests/Tests/Controllers/FetchedResultsControllerTestHarness.swift
@@ -10,15 +10,17 @@ import XCTest
 import Foundation
 @testable import FetchRequests
 
-// swiftlint:disable implicitly_unwrapped_optional
-
 @MainActor
 protocol FetchedResultsControllerTestHarness {
     associatedtype FetchController: FetchedResultsControllerProtocol where
         FetchController.FetchedObject == TestObject
 
+    // swiftlint:disable implicitly_unwrapped_optional
+
     var controller: FetchController! { get }
     var fetchCompletion: (([TestObject]) -> Void)! { get }
+
+    // swiftlint:enable implicitly_unwrapped_optional
 }
 
 extension FetchedResultsControllerTestHarness {
@@ -39,6 +41,7 @@ extension FetchedResultsControllerTestHarness {
         XCTAssertEqual(sortedObjects, controller.fetchedObjects, file: file, line: line)
     }
 
+    // swiftlint:disable:next implicitly_unwrapped_optional
     func getObjectAtIndex(_ index: Int, withObjectID objectID: String, file: StaticString = #file, line: UInt = #line) -> TestObject! {
         let object = controller.fetchedObjects[index]
 
@@ -50,20 +53,20 @@ extension FetchedResultsControllerTestHarness {
 
 extension FetchedResultsController where FetchedObject: TestObject {
     var fetchedIDs: [String] {
-        return fetchedObjects.map(\.id)
+        fetchedObjects.map(\.id)
     }
 
     var tags: [Int] {
-        return fetchedObjects.map(\.tag)
+        fetchedObjects.map(\.tag)
     }
 }
 
 extension FetchedResultsSection where FetchedObject: TestObject {
     var fetchedIDs: [String] {
-        return objects.map(\.id)
+        objects.map(\.id)
     }
 
     var tags: [Int] {
-        return objects.map(\.tag)
+        objects.map(\.tag)
     }
 }

--- a/FetchRequests/Tests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/PaginatingFetchedResultsControllerTestCase.swift
@@ -9,9 +9,9 @@
 import XCTest
 @testable import FetchRequests
 
-// swiftlint:disable force_try implicitly_unwrapped_optional
-
 class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTestHarness {
+    // swiftlint:disable implicitly_unwrapped_optional test_case_accessibility
+
     private(set) var controller: PaginatingFetchedResultsController<TestObject>!
 
     private(set) var fetchCompletion: (([TestObject]) -> Void)!
@@ -20,6 +20,8 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
     private var paginationCompletion: (([TestObject]?) -> Void)!
 
     private var associationRequest: TestObject.AssociationRequest!
+
+    // swiftlint:enable implicitly_unwrapped_optional test_case_accessibility
 
     private var inclusionCheck: ((TestObject.RawData) -> Bool)?
 
@@ -43,7 +45,7 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
         }
 
         let inclusionCheck: PaginatingFetchDefinition<TestObject>.CreationInclusionCheck = { [unowned self] rawData in
-            return self.inclusionCheck?(rawData) ?? true
+            self.inclusionCheck?(rawData) ?? true
         }
 
         return PaginatingFetchDefinition<TestObject>(
@@ -71,7 +73,7 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
         changeEvents = []
     }
 
-    func testBasicFetch() {
+    func testBasicFetch() throws {
         controller = PaginatingFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -79,13 +81,13 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         XCTAssertEqual(controller.sections.count, 1)
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs)
     }
 
-    func testResort() {
+    func testResort() throws {
         controller = PaginatingFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -93,7 +95,7 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
 
@@ -101,7 +103,7 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs.reversed())
     }
 
-    func testPaginationTriggersLoad() {
+    func testPaginationTriggersLoad() throws {
         controller = PaginatingFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -112,7 +114,7 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         fetchCompletion = nil
         paginationCurrentResults = nil
@@ -135,7 +137,7 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
         XCTAssertEqual(changeEvents[1].object.id, "f")
     }
 
-    func testPaginationDoesNotDisableInserts() {
+    func testPaginationDoesNotDisableInserts() throws {
         controller = PaginatingFetchedResultsController(
             definition: createFetchDefinition(),
             sortDescriptors: [
@@ -149,7 +151,7 @@ class PaginatingFetchedResultsControllerTestCase: XCTestCase, FetchedResultsCont
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         fetchCompletion = nil
         paginationCurrentResults = nil

--- a/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
+++ b/FetchRequests/Tests/Controllers/PausableFetchedResultsControllerTestCase.swift
@@ -9,14 +9,16 @@
 import XCTest
 @testable import FetchRequests
 
-// swiftlint:disable force_try implicitly_unwrapped_optional
-
 class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsControllerTestHarness {
+    // swiftlint:disable implicitly_unwrapped_optional test_case_accessibility
+
     private(set) var controller: PausableFetchedResultsController<TestObject>!
 
     private(set) var fetchCompletion: (([TestObject]) -> Void)!
 
     private var associationRequest: TestObject.AssociationRequest!
+
+    // swiftlint:enable implicitly_unwrapped_optional test_case_accessibility
 
     private var inclusionCheck: ((TestObject.RawData) -> Bool)?
 
@@ -36,7 +38,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
         }
 
         let inclusionCheck: FetchDefinition<TestObject>.CreationInclusionCheck = { [unowned self] rawData in
-            return self.inclusionCheck?(rawData) ?? true
+            self.inclusionCheck?(rawData) ?? true
         }
 
         return FetchDefinition<TestObject>(
@@ -59,7 +61,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
         inclusionCheck = nil
     }
 
-    func testBasicFetch() {
+    func testBasicFetch() throws {
         controller = PausableFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -67,13 +69,13 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         XCTAssertEqual(controller.sections.count, 1)
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs)
     }
 
-    func testResort() {
+    func testResort() throws {
         controller = PausableFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -81,7 +83,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         controller.resort(using: [NSSortDescriptor(keyPath: \TestObject.id, ascending: false)])
 
@@ -89,7 +91,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
         XCTAssertEqual(controller.sections[0].fetchedIDs, objectIDs.reversed())
     }
 
-    func testExpectInsertFromBroadcastNotification() {
+    func testExpectInsertFromBroadcastNotification() throws {
         controller = PausableFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -98,7 +100,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 
         let initialObjects = ["a", "b", "c"].compactMap { TestObject(id: $0) }
 
-        try! performFetch(initialObjects)
+        try performFetch(initialObjects)
 
         fetchCompletion = nil
         changeEvents.removeAll()
@@ -126,7 +128,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
         XCTAssert(changeEvents.isEmpty)
     }
 
-    func testExpectPausedInsertFromBroadcastNotification() {
+    func testExpectPausedInsertFromBroadcastNotification() throws {
         controller = PausableFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -135,7 +137,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 
         let initialObjects = ["a", "b", "c"].compactMap { TestObject(id: $0) }
 
-        try! performFetch(initialObjects)
+        try performFetch(initialObjects)
 
         fetchCompletion = nil
         changeEvents.removeAll()
@@ -172,7 +174,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
         XCTAssertEqual(changeEvents.count, 0)
     }
 
-    func testResetClearsPaused() {
+    func testResetClearsPaused() throws {
         controller = PausableFetchedResultsController(
             definition: createFetchDefinition(),
             debounceInsertsAndReloads: false
@@ -180,7 +182,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         controller.isPaused = true
 
@@ -189,7 +191,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
         XCTAssertFalse(controller.isPaused)
     }
 
-    func testWrappedProperties() {
+    func testWrappedProperties() throws {
         let fetchDefinition = createFetchDefinition()
 
         controller = PausableFetchedResultsController(
@@ -203,7 +205,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
             NSSelectorFromString("self"),
         ].map(\.description)
 
-        try! performFetch(["a", "b", "c"])
+        try performFetch(["a", "b", "c"])
 
         controller.associatedFetchSize = 20
 
@@ -218,7 +220,7 @@ class PausableFetchedResultsControllerTestCase: XCTestCase, FetchedResultsContro
 // MARK: - Paginating
 
 extension PausableFetchedResultsControllerTestCase {
-    func testCanCreatePausableVariation() {
+    func testCanCreatePausableVariation() throws {
         let baseDefinition = createFetchDefinition()
 
         var paginationRequests = 0
@@ -246,7 +248,7 @@ extension PausableFetchedResultsControllerTestCase {
 
         let objectIDs = ["a", "b", "c"]
 
-        try! performFetch(objectIDs)
+        try performFetch(objectIDs)
 
         controller.isPaused = true
         changeEvents.removeAll()

--- a/FetchRequests/Tests/Models/FetchRequestAssociationTestCase.swift
+++ b/FetchRequests/Tests/Models/FetchRequestAssociationTestCase.swift
@@ -11,30 +11,24 @@ import XCTest
 
 @MainActor
 class FetchRequestAssociationTestCase: XCTestCase {
-    typealias Association = FetchRequestAssociation<TestObject>
+    private typealias Association = FetchRequestAssociation<TestObject>
 
-    private var objects: [TestObject] = []
+    private let objects: [TestObject] = [
+        TestObject(id: "a", tag: 0),
+        TestObject(id: "b", tag: 1),
+        TestObject(id: "c", tag: 2),
+    ]
 
     private var objectIDs: [String] {
-        return objects.map(\.id)
+        objects.map(\.id)
     }
 
     private var tags: [Int] {
-        return objects.map(\.tag)
+        objects.map(\.tag)
     }
 
     private var tagIDs: [String] {
-        return objects.map(\.nonOptionalTagID)
-    }
-
-    override func setUp() {
-        super.setUp()
-
-        objects = [
-            TestObject(id: "a", tag: 0),
-            TestObject(id: "b", tag: 1),
-            TestObject(id: "c", tag: 2),
-        ]
+        objects.map(\.nonOptionalTagID)
     }
 }
 
@@ -408,7 +402,7 @@ extension FetchRequestAssociationTestCase {
         }
 
         let creationObserved: Association.CreationObserved<[TestObject], TestObject.RawData> = { lhs, rhs in
-            return .invalid
+            .invalid
         }
 
         let association = Association(
@@ -477,7 +471,7 @@ extension FetchRequestAssociationTestCase {
         }
 
         let creationObserved: Association.CreationObserved<[TestObject], TestObject.RawData> = { lhs, rhs in
-            return .invalid
+            .invalid
         }
 
         let association = Association(
@@ -696,50 +690,50 @@ extension FetchRequestAssociationTestCase {
 private extension TestObject {
     @objc
     dynamic var nonOptionalTagID: String {
-        return String(tag)
+        String(tag)
     }
 
     @objc
     dynamic var nonOptionalTagIDs: [String] {
-        return [nonOptionalTagID]
+        [nonOptionalTagID]
     }
 
     @objc
     dynamic var nonOptionalTagEntityID: TestFetchableEntityID {
-        return TestFetchableEntityID(id: nonOptionalTagID)
+        TestFetchableEntityID(id: nonOptionalTagID)
     }
 
     @objc
     dynamic var tagEntityID: TestFetchableEntityID? {
-        return tagID.map { TestFetchableEntityID(id: $0) }
+        tagID.map { TestFetchableEntityID(id: $0) }
     }
 
     @objc
     class func keyPathsForValuesAffectingNonOptionalTagID() -> Set<String> {
-        return [#keyPath(tag)]
+        [#keyPath(tag)]
     }
 
     @objc
     class func keyPathsForValuesAffectingNonOptionalTagIDs() -> Set<String> {
-        return [#keyPath(tag)]
+        [#keyPath(tag)]
     }
 
     @objc
     class func keyPathsForValuesAffectingTagEntityID() -> Set<String> {
-        return [#keyPath(tag)]
+        [#keyPath(tag)]
     }
 
     @objc
     class func keyPathsForValuesAffectingNonOptionalTagEntityID() -> Set<String> {
-        return [#keyPath(tag)]
+        [#keyPath(tag)]
     }
 
     var nonOptionalTagArrayEntityID: [TestFetchableEntityID] {
-        return [TestFetchableEntityID(id: nonOptionalTagID)]
+        [TestFetchableEntityID(id: nonOptionalTagID)]
     }
 
     var tagArrayEntityID: [TestFetchableEntityID]? {
-        return nonOptionalTagArrayEntityID
+        nonOptionalTagArrayEntityID
     }
 }
 
@@ -769,7 +763,7 @@ private final class TestFetchableEntityID: NSObject, FetchableEntityID {
     }
 
     class func fetch(byIDs objectIDs: [TestFetchableEntityID]) -> [TestObject] {
-        return TestObject.fetch(byIDs: objectIDs.map(\.id))
+        TestObject.fetch(byIDs: objectIDs.map(\.id))
     }
 
     class func fetch(byIDs objectIDs: [TestFetchableEntityID], completion: @escaping @MainActor ([TestObject]) -> Void) {

--- a/FetchRequests/Tests/Models/FetchRequestAssociationTestCase.swift
+++ b/FetchRequests/Tests/Models/FetchRequestAssociationTestCase.swift
@@ -44,11 +44,11 @@ extension FetchRequestAssociationTestCase {
     func testBasicNonOptionalAssociation() {
         let expected: [String: Int] = ["a": 2]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByParent<Int> = { [unowned self] objects, completion in
             XCTAssertEqual(objects, self.objects)
-            calledRequest = true
             completion(expected)
+            expectation.fulfill()
         }
 
         let association = Association(keyPath: \.tag, request: request)
@@ -59,7 +59,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: Int], expected)
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can't observe creation
 
@@ -86,11 +86,11 @@ extension FetchRequestAssociationTestCase {
     func testBasicOptionalAssociation() {
         let expected: [String: Int] = ["a": 2]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByParent<Int> = { objects, completion in
             XCTAssertEqual(objects, self.objects)
-            calledRequest = true
             completion(expected)
+            expectation.fulfill()
         }
 
         let association = Association(keyPath: \.tagID, request: request)
@@ -101,7 +101,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: Int], expected)
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can't observe creation
 
@@ -132,11 +132,11 @@ extension FetchRequestAssociationTestCase {
     func testCreatableNonOptionalAssociation() {
         let expected: [String: TestObject] = ["a": objects[0]]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByParent<TestObject> = { [unowned self] objects, completion in
             XCTAssertEqual(objects, self.objects)
-            calledRequest = true
             completion(expected)
+            expectation.fulfill()
         }
 
         let token = TestObjectTestToken()
@@ -157,7 +157,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: TestObject], expected)
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -195,11 +195,11 @@ extension FetchRequestAssociationTestCase {
     func testCreatableOptionalAssociation() {
         let expected: [String: TestObject] = ["a": objects[0]]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByParent<TestObject> = { [unowned self] objects, completion in
             XCTAssertEqual(objects, self.objects)
-            calledRequest = true
             completion(expected)
+            expectation.fulfill()
         }
 
         let token = TestObjectTestToken()
@@ -220,7 +220,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: TestObject], expected)
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -262,11 +262,12 @@ extension FetchRequestAssociationTestCase {
     func testCreatableNonOptionalAssociationByRawData() {
         let expected: [TestObject] = [TestObject(id: "0")]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByID<TestObject.ID, TestObject> = { [unowned self] objectIDs, completion in
             XCTAssertEqual(objectIDs, self.tagIDs)
-            calledRequest = true
             completion(expected)
+
+            expectation.fulfill()
         }
 
         let token = DataTestToken()
@@ -288,7 +289,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: TestObject], ["a": expected[0]])
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -326,11 +327,11 @@ extension FetchRequestAssociationTestCase {
     func testCreatableOptionalAssociationByRawData() {
         let expected: [TestObject] = [TestObject(id: "0")]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByID<TestObject.ID, TestObject> = { [unowned self] objectIDs, completion in
             XCTAssertEqual(objectIDs, self.tagIDs)
-            calledRequest = true
             completion(expected)
+            expectation.fulfill()
         }
 
         let token = DataTestToken()
@@ -352,7 +353,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: TestObject], ["a": expected[0]])
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -394,11 +395,11 @@ extension FetchRequestAssociationTestCase {
     func testCreatableNonOptionalArrayAssociationByRawData() {
         let expected: [TestObject] = [TestObject(id: "0")]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByID<TestObject.ID, TestObject> = { [unowned self] objectIDs, completion in
             XCTAssertEqual(objectIDs, self.tagIDs)
-            calledRequest = true
             completion(expected)
+            expectation.fulfill()
         }
 
         let token = DataTestToken()
@@ -424,7 +425,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: [TestObject]], ["a": expected])
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -462,11 +463,12 @@ extension FetchRequestAssociationTestCase {
     func testCreatableOptionalArrayAssociationByRawData() {
         let expected: [TestObject] = [TestObject(id: "0")]
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         let request: Association.AssocationRequestByID<TestObject.ID, TestObject> = { [unowned self] objectIDs, completion in
             XCTAssertEqual(objectIDs, self.tagIDs)
-            calledRequest = true
             completion(expected)
+
+            expectation.fulfill()
         }
 
         let token = DataTestToken()
@@ -492,7 +494,7 @@ extension FetchRequestAssociationTestCase {
             XCTAssertEqual(results as? [String: [TestObject]], ["a": expected])
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -549,13 +551,13 @@ extension FetchRequestAssociationTestCase {
             memo[element.id] = TestObject(id: element.nonOptionalTagID)
         }
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         association.request(objects) { results in
-            calledRequest = true
             XCTAssertEqual(results as? [String: TestObject], expected)
+            expectation.fulfill()
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -608,13 +610,13 @@ extension FetchRequestAssociationTestCase {
             memo[element.id] = TestObject(id: element.nonOptionalTagID)
         }
 
-        var calledRequest = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         association.request(objects) { results in
-            calledRequest = true
             XCTAssertEqual(results as? [String: TestObject], expected)
+            expectation.fulfill()
         }
 
-        XCTAssertTrue(calledRequest)
+        wait(for: [expectation], timeout: 5)
 
         // Verify we can observe creation
 
@@ -657,13 +659,13 @@ extension FetchRequestAssociationTestCase {
 
         XCTAssertEqual(TestFetchableEntityID.fetch(byID: id), object)
 
-        var called = false
+        let expectation = XCTestExpectation(description: "calledRequest")
         TestFetchableEntityID.fetch(byID: id) { result in
             XCTAssertEqual(result, object)
-            called = true
+            expectation.fulfill()
         }
 
-        XCTAssertTrue(called)
+        wait(for: [expectation], timeout: 5)
     }
 
     func testFaultByEntityID() {
@@ -770,8 +772,10 @@ private final class TestFetchableEntityID: NSObject, FetchableEntityID {
         return TestObject.fetch(byIDs: objectIDs.map(\.id))
     }
 
-    class func fetch(byIDs objectIDs: [TestFetchableEntityID], completion: @escaping ([TestObject]) -> Void) {
-        completion(self.fetch(byIDs: objectIDs))
+    class func fetch(byIDs objectIDs: [TestFetchableEntityID], completion: @escaping @MainActor ([TestObject]) -> Void) {
+        Task {
+            await completion(self.fetch(byIDs: objectIDs))
+        }
     }
 }
 

--- a/FetchRequests/Tests/Models/JSONTestCase.swift
+++ b/FetchRequests/Tests/Models/JSONTestCase.swift
@@ -131,7 +131,7 @@ extension JSONTestCase {
 
 extension JSONTestCase {
     private var complexJSON: JSON {
-        return [
+        [
             "id": 1,
             "integers": [0, 1, 2],
             "foo": [
@@ -330,13 +330,13 @@ extension JSONTestCase {
     }
 
     private var sourceJSON: [String: Any] {
-        return [
+        [
             "elements": [
                 1,
                 2.5,
                 "string",
                 true,
-            ],
+            ] as [Any],
             "nullable": NSNull(),
         ]
     }

--- a/FetchRequests/Tests/TestObject+Associations.swift
+++ b/FetchRequests/Tests/TestObject+Associations.swift
@@ -9,23 +9,21 @@
 import Foundation
 @testable import FetchRequests
 
-// swiftlint:disable implicitly_unwrapped_optional
-
 extension TestObject {
     func tagString() -> String? {
-        return performFault(on: \.tag) { tag in
+        performFault(on: \.tag) { tag in
             fatalError("Cannot perform fallback fault")
         }
     }
 
     func tagObject() -> TestObject? {
-        return performFault(on: \.tagID) { (tagID: String) -> TestObject? in
+        performFault(on: \.tagID) { (tagID: String) -> TestObject? in
             fatalError("Cannot perform fallback fault")
         }
     }
 
     func tagObjectArray() -> [TestObject]? {
-        return performFault(on: \.tagIDs) { (tagIDs: [String]) -> [TestObject]? in
+        performFault(on: \.tagIDs) { (tagIDs: [String]) -> [TestObject]? in
             fatalError("Cannot perform fallback fault")
         }
     }
@@ -37,6 +35,8 @@ extension TestObject {
     enum AssociationRequest {
         case parents([TestObject], completion: @MainActor ([String: String]) -> Void)
         case tagIDs([String], completion: @MainActor ([TestObject]) -> Void)
+
+        // swiftlint:disable implicitly_unwrapped_optional
 
         var parentIDs: [String]! {
             guard case let .parents(objects, _) = self else {
@@ -65,6 +65,8 @@ extension TestObject {
             }
             return completion
         }
+
+        // swiftlint:enable implicitly_unwrapped_optional
     }
 
     static func fetchRequestAssociations(
@@ -163,7 +165,7 @@ class VoidNotificationObservableToken: WrappedObservableToken<Void> {
 
 extension TestObject {
     static func fetch(byIDs ids: [TestObject.ID]) -> [TestObject] {
-        return ids.map { TestObject(id: $0) }
+        ids.map { TestObject(id: $0) }
     }
 }
 
@@ -178,7 +180,7 @@ extension FetchRequestAssociation where FetchedObject == TestObject {
             keyPath: keyPath,
             request: request,
             creationTokenGenerator: { objectID in
-                return TestEntityObservableToken(
+                TestEntityObservableToken(
                     name: AssociatedType.objectWasCreated(),
                     include: { rawData in
                         guard let includeID = AssociatedType.entityID(from: rawData) else {
@@ -202,7 +204,7 @@ extension FetchRequestAssociation where FetchedObject == TestObject {
             keyPath: keyPath,
             request: request,
             creationTokenGenerator: { objectIDs in
-                return TestEntityObservableToken(
+                TestEntityObservableToken(
                     name: AssociatedType.objectWasCreated(),
                     include: { rawData in
                         guard let objectID = AssociatedType.entityID(from: rawData) else {

--- a/FetchRequests/Tests/TestObject+FetchableObject.swift
+++ b/FetchRequests/Tests/TestObject+FetchableObject.swift
@@ -13,7 +13,7 @@ import FetchRequests
 
 extension TestObject: FetchableObjectProtocol {
     func observeDataChanges(_ handler: @escaping @MainActor () -> Void) -> InvalidatableToken {
-        return self.observe(\.data, options: [.old, .new]) { object, change in
+        self.observe(\.data, options: [.old, .new]) { object, change in
             guard let old = change.oldValue, let new = change.newValue, old != new else {
                 return
             }
@@ -23,7 +23,7 @@ extension TestObject: FetchableObjectProtocol {
     }
 
     func observeIsDeletedChanges(_ handler: @escaping @MainActor () -> Void) -> InvalidatableToken {
-        return self.observe(\.isDeleted, options: [.old, .new]) { object, change in
+        self.observe(\.isDeleted, options: [.old, .new]) { object, change in
             guard let old = change.oldValue, let new = change.newValue, old != new else {
                 return
             }
@@ -32,7 +32,7 @@ extension TestObject: FetchableObjectProtocol {
     }
 
     static func entityID(from data: RawData) -> ID? {
-        return data.id?.string
+        data.id?.string
     }
 }
 
@@ -47,10 +47,10 @@ private func unsafeHandler(for handler: @MainActor () -> Void) {
 
 extension TestObject {
     static func objectWasCreated() -> Notification.Name {
-        return Notification.Name("TestObject.objectWasCreated")
+        Notification.Name("TestObject.objectWasCreated")
     }
 
     static func dataWasCleared() -> Notification.Name {
-        return Notification.Name("TestObject.dataWasCleared")
+        Notification.Name("TestObject.dataWasCleared")
     }
 }

--- a/FetchRequests/Tests/TestObject.swift
+++ b/FetchRequests/Tests/TestObject.swift
@@ -74,21 +74,21 @@ final class TestObject: NSObject {
 extension TestObject {
     @objc
     dynamic var tagID: String? {
-        return String(tag)
+        String(tag)
     }
 
     @objc
     dynamic var tagIDs: [String]? {
-        return tagID.map { [$0] }
+        tagID.map { [$0] }
     }
 
     @objc
     class func keyPathsForValuesAffectingTagID() -> Set<String> {
-        return [#keyPath(tag)]
+        [#keyPath(tag)]
     }
 
     @objc
     class func keyPathsForValuesAffectingTagIDs() -> Set<String> {
-        return [#keyPath(tag)]
+        [#keyPath(tag)]
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,11 @@ import PackageDescription
 let package = Package(
     name: "FetchRequests",
     platforms: [
-        .macCatalyst(.v13),
-        .iOS(.v13),
-        .tvOS(.v13),
-        .watchOS(.v6),
-        .macOS(.v10_15),
+        .macCatalyst(.v14),
+        .iOS(.v14),
+        .tvOS(.v14),
+        .watchOS(.v7),
+        .macOS(.v11),
     ],
     products: [
         .library(


### PR DESCRIPTION
In practice, the associations code _always_ bounced to main anyways.
This lets us clean up a bunch of internal code by marking it @MainActor

This is nominally a breaking change, so it implies a major version change.
As that's the case, I updated the supported OSes to reflect our internal minimums.

> MAJOR version when you make incompatible API changes

## Note

To keep the diff minimal, I did not touch linter updates. That was done in https://github.com/square/FetchRequests/pull/45