### PR TITLE
Add async operations and pagination completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 `FetchRequests` adheres to [Semantic Versioning](https://semver.org/).
 
-## 6.0.4
+## 6.1.0
 Release TBD
 
 * Adds async operations for fetch and resort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 `FetchRequests` adheres to [Semantic Versioning](https://semver.org/).
 
+## 6.0.4
+Release TBD
+
+* Adds async operations for fetch and resort
+* Adds completion closure to performPagination, with a boolean value indicating if values were returned or not  
+
 ## [6.0.3](https://github.com/square/FetchRequests/releases/tag/6.0.3)
 Released on 2024-03-06
 
@@ -17,7 +23,7 @@ Released on 2023-06-23
 
 * The demo now includes a SwiftUI example
 * Fix for SwiftUI when a FetchDefinition request is synchronous
-
+    
 ## [6.0](https://github.com/square/FetchRequests/releases/tag/6.0.0)
 Released on 2023-04-05
 

--- a/FetchRequests/Sources/Controller/FetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsController.swift
@@ -238,7 +238,8 @@ public class FetchedResultsController<FetchedObject: FetchableObject>: NSObject,
         return new
     }
 
-    private let debounceInsertsAndReloads: Bool
+    internal let debounceInsertsAndReloads: Bool
+
     private var objectsToReload: Set<FetchedObject> = []
     private var objectsToInsert: OrderedSet<FetchedObject> = []
 

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -45,12 +45,29 @@ public protocol FetchedResultsControllerProtocol<FetchedObject>: DoublyObservabl
     @MainActor
     func reset()
 
-    @MainActor
-    func performFetch() async
-    @MainActor
-    func resort(using newSortDescriptors: [NSSortDescriptor]) async
-
     func indexPath(for object: FetchedObject) -> IndexPath?
+}
+
+// MARK: - Async
+
+public extension FetchedResultsControllerProtocol {
+    @MainActor
+    func performFetch() async {
+        await withCheckedContinuation { continuation in
+            performFetch {
+                continuation.resume()
+            }
+        }
+    }
+
+    @MainActor
+    func resort(using newSortDescriptors: [NSSortDescriptor]) async {
+        await withCheckedContinuation { continuation in
+            resort(using: sortDescriptors) {
+                continuation.resume()
+            }
+        }
+    }
 }
 
 // MARK: - Index Paths
@@ -62,26 +79,8 @@ public extension FetchedResultsControllerProtocol {
     }
 
     @MainActor
-    func performFetch() async {
-        await withCheckedContinuation { continuation in
-            performFetch {
-                continuation.resume()
-            }
-        }
-    }
-
-    @MainActor
     func resort(using newSortDescriptors: [NSSortDescriptor]) {
         resort(using: newSortDescriptors, completion: {})
-    }
-
-    @MainActor
-    func resort(using newSortDescriptors: [NSSortDescriptor]) async {
-        await withCheckedContinuation { continuation in
-            resort(using: sortDescriptors) {
-                continuation.resume()
-            }
-        }
     }
 
     internal func idealSectionIndex(forSectionName name: String) -> Int {

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -45,6 +45,11 @@ public protocol FetchedResultsControllerProtocol<FetchedObject>: DoublyObservabl
     @MainActor
     func reset()
 
+    @MainActor
+    func performFetch() async
+    @MainActor
+    func resort(using newSortDescriptors: [NSSortDescriptor]) async
+
     func indexPath(for object: FetchedObject) -> IndexPath?
 }
 
@@ -57,8 +62,26 @@ public extension FetchedResultsControllerProtocol {
     }
 
     @MainActor
+    func performFetch() async {
+        await withCheckedContinuation { continuation in
+            performFetch {
+                continuation.resume()
+            }
+        }
+    }
+
+    @MainActor
     func resort(using newSortDescriptors: [NSSortDescriptor]) {
         resort(using: newSortDescriptors, completion: {})
+    }
+
+    @MainActor
+    func resort(using newSortDescriptors: [NSSortDescriptor]) async {
+        await withCheckedContinuation { continuation in
+            resort(using: sortDescriptors) {
+                continuation.resume()
+            }
+        }
     }
 
     internal func idealSectionIndex(forSectionName name: String) -> Int {

--- a/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
+++ b/FetchRequests/Sources/Controller/PausableFetchedResultsController.swift
@@ -174,6 +174,10 @@ extension PausableFetchedResultsController: FetchedResultsControllerProtocol {
     public var sections: [Section] {
         sectionsSnapshot ?? controller.sections
     }
+
+    internal var debounceInsertsAndReloads: Bool {
+        controller.debounceInsertsAndReloads
+    }
 }
 
 // MARK: - InternalFetchResultsControllerProtocol

--- a/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
+++ b/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
@@ -42,8 +42,8 @@ private extension InternalFetchResultsControllerProtocol {
     @MainActor
     func performPagination(
         with paginationRequest: PaginatingFetchDefinition<FetchedObject>.PaginationRequest,
-        debounceInsertsAndReloads: Bool,
-        completion: @escaping (_ hasPageResults: Bool) -> Void
+        willDebounceInsertsAndReloads: Bool,
+        completion: @MainActor @escaping (_ hasPageResults: Bool) -> Void
     ) {
         let currentResults = self.fetchedObjects
         paginationRequest(currentResults) { [weak self] pageResults in
@@ -56,7 +56,7 @@ private extension InternalFetchResultsControllerProtocol {
                 self?.manuallyInsert(objects: pageResults, emitChanges: true)
             }
 
-            if debounceInsertsAndReloads {
+            if willDebounceInsertsAndReloads {
                 // force this to run on the _next_ run loop, at which point any debounced insertions should have happened
                 DispatchQueue.main.async {
                     completion(!pageResults.isEmpty)
@@ -90,10 +90,10 @@ public class PaginatingFetchedResultsController<
     }
 
     @MainActor
-    public func performPagination(completion: @escaping (_ hasPageResults: Bool) -> Void = { _ in }) {
+    public func performPagination(completion: @MainActor @escaping (_ hasPageResults: Bool) -> Void = { _ in }) {
         performPagination(
             with: paginatingDefinition.paginationRequest,
-            debounceInsertsAndReloads: debounceInsertsAndReloads,
+            willDebounceInsertsAndReloads: debounceInsertsAndReloads,
             completion: completion
         )
     }
@@ -133,7 +133,7 @@ public class PausablePaginatingFetchedResultsController<
     public func performPagination() {
         performPagination(
             with: paginatingDefinition.paginationRequest,
-            debounceInsertsAndReloads: debounceInsertsAndReloads,
+            willDebounceInsertsAndReloads: debounceInsertsAndReloads,
             completion: { _ in }
         )
     }

--- a/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
+++ b/FetchRequests/Sources/Requests/PaginatingFetchDefinition.swift
@@ -43,7 +43,7 @@ private extension InternalFetchResultsControllerProtocol {
     func performPagination(
         with paginationRequest: PaginatingFetchDefinition<FetchedObject>.PaginationRequest,
         willDebounceInsertsAndReloads: Bool,
-        completion: @MainActor @escaping (_ hasPageResults: Bool) -> Void
+        completion: @escaping @MainActor (_ hasPageResults: Bool) -> Void
     ) {
         let currentResults = self.fetchedObjects
         paginationRequest(currentResults) { [weak self] pageResults in
@@ -90,7 +90,7 @@ public class PaginatingFetchedResultsController<
     }
 
     @MainActor
-    public func performPagination(completion: @MainActor @escaping (_ hasPageResults: Bool) -> Void = { _ in }) {
+    public func performPagination(completion: @escaping @MainActor (_ hasPageResults: Bool) -> Void = { _ in }) {
         performPagination(
             with: paginatingDefinition.paginationRequest,
             willDebounceInsertsAndReloads: debounceInsertsAndReloads,


### PR DESCRIPTION
- Add support for async fetching, returning when completion closure of closure based version would be called
- Add completion callback to `performPagination` , informing consumers if the page request returned results. 
- Tests for check completion values