### PR TITLE
Restore swift 5 compilations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - tvOS
           - watchOS
           - macOS
-          - visionOS
+          #- visionOS # These runtimes are missing?
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -29,7 +29,8 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           scheme: FetchRequests-${{ matrix.platform }}
-          swift: ~6.0
+          #swift: ~6.0
+          xcode: '16.0.0' # It's currently preferring 16.1 beta
           action: test
           code-coverage: true
       - name: Code Coverage
@@ -56,6 +57,7 @@ jobs:
         with:
           platform: iOS
           scheme: iOS Example
-          swift: ~6.0
+          #swift: ~6.0
+          xcode: '16.0.0' # It's currently preferring 16.1 beta
           action: build
           working-directory: Example

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,9 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
-# Package.resolved
+Package.resolved
 .build/
+.swiftpm/
 
 # CocoaPods
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 All notable changes to this project will be documented in this file.
 `FetchRequests` adheres to [Semantic Versioning](https://semver.org/).
 
+## [7.0.1](https://github.com/square/FetchRequests/releases/tag/7.0.1)
+Release 2024-09-26
+
+* Restore support for Swift 5 compiler
+
 ## [7.0](https://github.com/square/FetchRequests/releases/tag/7.0.0)
-Release 2024-09-XX
+Release 2024-09-11
 
 * Compiles cleanly in the Swift 6 language mode
 * Requires the Swift 6 compiler

--- a/FetchRequests.podspec
+++ b/FetchRequests.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.macos.deployment_target = macos_deployment_target
   s.visionos.deployment_target = visionos_deployment_target
 
-  s.swift_version = '5.0'
+  s.swift_versions = ['5.0', '6.0']
 
   s.source_files = [
     'FetchRequests/simplediff-swift/simplediff.swift',

--- a/FetchRequests.podspec
+++ b/FetchRequests.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'FetchRequests'
-  s.version = '7.0.0'
+  s.version = '7.0.1'
   s.license = 'MIT'
   s.summary = 'NSFetchedResultsController inspired eventing'
   s.homepage = 'https://github.com/square/FetchRequests'

--- a/FetchRequests/Sources/Associations/AssociatedValueReference.swift
+++ b/FetchRequests/Sources/Associations/AssociatedValueReference.swift
@@ -10,10 +10,16 @@ import Foundation
 
 // MARK: - Internal Structures
 
-struct AssociatedValueKey<FetchedObject: FetchableObject>: Hashable, Sendable {
+struct AssociatedValueKey<FetchedObject: FetchableObject>: Hashable {
     var id: FetchedObject.ID
-    var keyPath: PartialKeyPath<FetchedObject> & Sendable
+    var keyPath: FetchRequestAssociation<FetchedObject>.AssociationKeyPath
 }
+
+#if compiler(>=6)
+extension AssociatedValueKey: Sendable {}
+#else
+extension AssociatedValueKey: @unchecked Sendable {}
+#endif
 
 class FetchableAssociatedValueReference<Entity: FetchableObject>: AssociatedValueReference, @unchecked Sendable {
     private var observations: [Entity: [InvalidatableToken]] = [:]

--- a/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
+++ b/FetchRequests/Sources/Associations/FetchRequestAssociation.swift
@@ -31,8 +31,18 @@ public class FetchRequestAssociation<FetchedObject: FetchableObject> {
     /// Start observing a source object
     public typealias TokenGenerator<Source, Token: ObservableToken> = (Source) -> Token?
 
+#if compiler(>=6)
     internal typealias AssociationKeyPath = PartialKeyPath<FetchedObject> & Sendable
+#else
+    internal typealias AssociationKeyPath = PartialKeyPath<FetchedObject>
+#endif
     internal typealias ReferenceGenerator = (FetchedObject) -> AssociatedValueReference
+
+#if compiler(>=6)
+    public typealias EntityKeyPath<T> = KeyPath<FetchedObject, T> & Sendable
+#else
+    public typealias EntityKeyPath<T> = KeyPath<FetchedObject, T>
+#endif
 
     internal let keyPath: AssociationKeyPath
     internal let request: AssocationRequestByParent<Any>
@@ -87,7 +97,7 @@ public class FetchRequestAssociation<FetchedObject: FetchableObject> {
 public extension FetchRequestAssociation {
     /// Association by non-optional entity ID
     convenience init<AssociatedEntity, AssociatedEntityID: Equatable>(
-        keyPath: KeyPath<FetchedObject, AssociatedEntityID> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntityID>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>
     ) {
         self.init(
@@ -115,7 +125,7 @@ public extension FetchRequestAssociation {
 
     /// Association by optional entity ID
     convenience init<AssociatedEntity, AssociatedEntityID: Equatable>(
-        keyPath: KeyPath<FetchedObject, AssociatedEntityID?> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntityID?>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>
     ) {
         self.init(
@@ -152,7 +162,7 @@ public extension FetchRequestAssociation {
         AssociatedEntityID: Equatable,
         Token: ObservableToken<RawAssociatedEntity>
     >(
-        keyPath: KeyPath<FetchedObject, AssociatedEntityID> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntityID>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         creationObserved: @escaping CreationObserved<AssociatedEntity, RawAssociatedEntity>
@@ -219,7 +229,7 @@ public extension FetchRequestAssociation {
         AssociatedEntityID: Equatable,
         Token: ObservableToken<RawAssociatedEntity>
     >(
-        keyPath: KeyPath<FetchedObject, AssociatedEntityID?> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntityID?>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         creationObserved: @escaping CreationObserved<AssociatedEntity, RawAssociatedEntity>
@@ -285,7 +295,7 @@ public extension FetchRequestAssociation {
         AssociatedEntityID: Equatable,
         Token: ObservableToken<AssociatedEntity>
     >(
-        keyPath: KeyPath<FetchedObject, AssociatedEntityID> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntityID>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         preferExistingValueOnCreate: Bool
@@ -309,7 +319,7 @@ public extension FetchRequestAssociation {
         AssociatedEntityID: Equatable,
         Token: ObservableToken<AssociatedEntity>
     >(
-        keyPath: KeyPath<FetchedObject, AssociatedEntityID?> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntityID?>,
         request: @escaping AssocationRequestByParent<AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<FetchedObject, Token>,
         preferExistingValueOnCreate: Bool
@@ -337,7 +347,7 @@ public extension FetchRequestAssociation {
         Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: AssociatedEntity.Type,
-        keyPath: KeyPath<FetchedObject, AssociatedEntity.ID> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntity.ID>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<AssociatedEntity.ID, Token>,
         preferExistingValueOnCreate: Bool
@@ -427,7 +437,7 @@ public extension FetchRequestAssociation {
         Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: AssociatedEntity.Type,
-        keyPath: KeyPath<FetchedObject, AssociatedEntity.ID?> & Sendable,
+        keyPath: EntityKeyPath<AssociatedEntity.ID?>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<AssociatedEntity.ID, Token>,
         preferExistingValueOnCreate: Bool
@@ -525,7 +535,7 @@ public extension FetchRequestAssociation {
         Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
-        keyPath: KeyPath<FetchedObject, [AssociatedEntity.ID]> & Sendable,
+        keyPath: EntityKeyPath<[AssociatedEntity.ID]>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<[AssociatedEntity.ID], Token>,
         creationObserved: @escaping CreationObserved<[AssociatedEntity], AssociatedEntity.RawData>
@@ -547,7 +557,7 @@ public extension FetchRequestAssociation {
         Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
-        keyPath: KeyPath<FetchedObject, [Reference]> & Sendable,
+        keyPath: EntityKeyPath<[Reference]>,
         request: @escaping AssocationRequestByID<Reference, AssociatedEntity>,
         referenceAccessor: @escaping @Sendable (AssociatedEntity) -> Reference,
         creationTokenGenerator: @escaping TokenGenerator<[Reference], Token>,
@@ -653,7 +663,7 @@ public extension FetchRequestAssociation {
         Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
-        keyPath: KeyPath<FetchedObject, [AssociatedEntity.ID]?> & Sendable,
+        keyPath: EntityKeyPath<[AssociatedEntity.ID]?>,
         request: @escaping AssocationRequestByID<AssociatedEntity.ID, AssociatedEntity>,
         creationTokenGenerator: @escaping TokenGenerator<[AssociatedEntity.ID], Token>,
         creationObserved: @escaping CreationObserved<[AssociatedEntity], AssociatedEntity.RawData>
@@ -675,7 +685,7 @@ public extension FetchRequestAssociation {
         Token: ObservableToken<AssociatedEntity.RawData>
     >(
         for associatedType: [AssociatedEntity].Type,
-        keyPath: KeyPath<FetchedObject, [Reference]?> & Sendable,
+        keyPath: EntityKeyPath<[Reference]?>,
         request: @escaping AssocationRequestByID<Reference, AssociatedEntity>,
         referenceAccessor: @escaping @Sendable (AssociatedEntity) -> Reference,
         creationTokenGenerator: @escaping TokenGenerator<[Reference], Token>,
@@ -784,7 +794,7 @@ public extension FetchRequestAssociation {
         EntityID: FetchableEntityID,
         Token: ObservableToken<EntityID.FetchableEntity.RawData>
     >(
-        keyPath: KeyPath<FetchedObject, EntityID> & Sendable,
+        keyPath: EntityKeyPath<EntityID>,
         creationTokenGenerator: @escaping TokenGenerator<EntityID, Token>,
         preferExistingValueOnCreate: Bool
     ) {
@@ -856,7 +866,7 @@ public extension FetchRequestAssociation {
         EntityID: FetchableEntityID,
         Token: ObservableToken<EntityID.FetchableEntity.RawData>
     >(
-        keyPath: KeyPath<FetchedObject, EntityID?> & Sendable,
+        keyPath: EntityKeyPath<EntityID?>,
         creationTokenGenerator: @escaping TokenGenerator<EntityID, Token>,
         preferExistingValueOnCreate: Bool
     ) {

--- a/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
+++ b/FetchRequests/Sources/Controller/FetchedResultsControllerProtocol.swift
@@ -23,7 +23,7 @@ public protocol DoublyObservableObject: ObservableObject {
 public protocol FetchedResultsControllerProtocol<FetchedObject>: DoublyObservableObject {
     associatedtype FetchedObject: FetchableObject
 
-    typealias SectionNameKeyPath = KeyPath<FetchedObject, String> & Sendable
+    typealias SectionNameKeyPath = FetchedResultsController<FetchedObject>.SectionNameKeyPath
     typealias Section = FetchedResultsSection<FetchedObject>
 
     var definition: FetchDefinition<FetchedObject> { get }

--- a/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
+++ b/FetchRequests/Sources/SwiftUI/FetchableRequest.swift
@@ -8,8 +8,14 @@ import Foundation
 import Combine
 import SwiftUI
 
+#if compiler(>=6)
+extension SectionedFetchableRequest: @preconcurrency DynamicProperty {}
+#else
+extension SectionedFetchableRequest: DynamicProperty {}
+#endif
+
 @propertyWrapper
-public struct SectionedFetchableRequest<FetchedObject: FetchableObject>: @preconcurrency DynamicProperty {
+public struct SectionedFetchableRequest<FetchedObject: FetchableObject> {
     @FetchableRequest
     private var base: FetchableResults<FetchedObject>
 
@@ -24,7 +30,7 @@ public struct SectionedFetchableRequest<FetchedObject: FetchableObject>: @precon
 
     public init(
         definition: FetchDefinition<FetchedObject>,
-        sectionNameKeyPath: KeyPath<FetchedObject, String> & Sendable,
+        sectionNameKeyPath: FetchedResultsController<FetchedObject>.SectionNameKeyPath,
         sortDescriptors: [NSSortDescriptor] = [],
         debounceInsertsAndReloads: Bool = true,
         animation: Animation? = nil
@@ -49,8 +55,14 @@ private class Opaque<T> {
     var value: T?
 }
 
+#if compiler(>=6)
+extension FetchableRequest: @preconcurrency DynamicProperty {}
+#else
+extension FetchableRequest: DynamicProperty {}
+#endif
+
 @propertyWrapper
-public struct FetchableRequest<FetchedObject: FetchableObject>: @preconcurrency DynamicProperty {
+public struct FetchableRequest<FetchedObject: FetchableObject> {
     @State
     public private(set) var wrappedValue = FetchableResults<FetchedObject>()
 

--- a/FetchRequests/Tests/TestObject+Associations.swift
+++ b/FetchRequests/Tests/TestObject+Associations.swift
@@ -172,7 +172,7 @@ extension TestObject {
 extension FetchRequestAssociation where FetchedObject == TestObject {
     convenience init<AssociatedType: TestObject>(
         for associatedType: AssociatedType.Type,
-        keyPath: KeyPath<FetchedObject, AssociatedType.ID?> & Sendable,
+        keyPath: EntityKeyPath<AssociatedType.ID?>,
         request: @escaping AssocationRequestByID<AssociatedType.ID, AssociatedType>
     ) {
         self.init(
@@ -196,7 +196,7 @@ extension FetchRequestAssociation where FetchedObject == TestObject {
 
     convenience init<AssociatedType: TestObject>(
         for associatedType: [AssociatedType].Type,
-        keyPath: KeyPath<FetchedObject, [AssociatedType.ID]?> & Sendable,
+        keyPath: EntityKeyPath<[AssociatedType.ID]?>,
         request: @escaping AssocationRequestByID<AssociatedType.ID, AssociatedType>
     ) {
         self.init(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,0 +1,40 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "FetchRequests",
+    platforms: [
+        .macCatalyst(.v14),
+        .iOS(.v14),
+        .tvOS(.v14),
+        .watchOS(.v7),
+        .macOS(.v11),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "FetchRequests",
+            targets: ["FetchRequests"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "FetchRequests",
+            dependencies: [
+                .product(name: "Collections", package: "swift-collections"),
+            ],
+            path: "FetchRequests",
+            exclude: ["Tests", "Info.plist", "TestsInfo.plist"]
+        ),
+        .testTarget(
+            name: "FetchRequestsTests",
+            dependencies: ["FetchRequests"],
+            path: "FetchRequests/Tests"
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
The two _main_ issues were:
* `KeyPath<> & Sendable`
* Thunks

I mostly don't care about this except that older versions of SPM are getting very confused since the `swift-tools-version` was too high